### PR TITLE
Closes #258

### DIFF
--- a/man/lossless_convert.Rd
+++ b/man/lossless_convert.Rd
@@ -2,9 +2,10 @@
 % Please edit documentation in R/utilities.R
 \name{lossless_convert}
 \alias{lossless_convert}
-\title{Convert the class of a vector to another class is possible without introducing additional NAs}
+\title{Convert the class of a vector to another class -- when possible without
+introducing additional NAs}
 \usage{
-lossless_convert(x = NULL, class = NULL)
+lossless_convert(x, class)
 }
 \arguments{
 \item{x}{vector of indeterminate length and type}
@@ -16,15 +17,20 @@ lossless_convert(x = NULL, class = NULL)
 a vector of the same length as x, but of the new class (when possible)
 }
 \description{
-Convert the class of a vector to another class is possible without introducing additional NAs
+Convert the class of a vector to another class -- when possible without
+introducing additional NAs. If NAs would be introduced, the original vector
+will be returned along with a warning so the user knows it has not been
+converted.
 }
 \examples{
-temp <- 1:10
-temp <- lossless_convert(temp, 'character')
-str(temp)
-temp <- lossless_convert(temp, 'integer')
-str(temp)
-temp <- lossless_convert(temp, 'numeric')
-str(temp)
+\donttest{
+str(lossless_convert(c('1', '2', '3'), 'integer'))
+str(lossless_convert(c('one', '2', '3'), 'integer'))
+str(lossless_convert(c('1', '2', 'three'), 'integer'))
+
+str(lossless_convert(c('2020-01-01', '2021-12-31', '2022-02-22'), 'Date'))
+str(lossless_convert(c('2020-01-01', '2021-12-31', 'z'), 'Date'))
+str(lossless_convert(c('z', '2020-01-01', '2021-12-31'), 'Date'))
+}
 
 }

--- a/man/validate_yaml_data.Rd
+++ b/man/validate_yaml_data.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/utilities.R
 \name{validate_yaml_data}
 \alias{validate_yaml_data}
-\title{Compare the expected column types in YAML with the actual column types in R}
+\title{validate the structure and data types of a data.frame or data.table against
+specifications defined in a YAML file}
 \usage{
 validate_yaml_data(ph.data = NULL, YML = NULL, VARS = "vars")
 }
@@ -17,7 +18,11 @@ validate_yaml_data(ph.data = NULL, YML = NULL, VARS = "vars")
 A simple printed statement, either identifying incompatible column types or a statement of success
 }
 \description{
-Compare the expected column types in YAML with the actual column types in R
+Validate the structure and data types of a data.frame or data.table against
+specifications defined in a YAML file. This is most often used to check that
+your data.frame or data.table is suitable to be pushed to TSQL when a YAML
+file specifies the field.types to be used by \code{DBI::dbWriteTable} &
+\code{odbc::dbWriteTable}.
 }
 \examples{
 library(data.table)

--- a/tests/testthat/test_utilities.R
+++ b/tests/testthat/test_utilities.R
@@ -1,38 +1,6 @@
 library('testthat')
 library(DBI)
 
-# format_time() ----
-test_that('format_time',{
-
-  expect_equal('2010', format_time(2010))
-
-  expect_equal('2000, 2014-2016, 3000, 3002-4000', format_time(c(2000, 2014:2016, 3000, 3002:4000)))
-
-  expect_equal('2000, 2014-2016, 3000, 3002-4000', format_time(c(3002:4000, 2000, 2014:2016, 3000)))
-
-
-})
-
-# list_ref_pop() ----
-test_that('list_ref_pop',{
-
-  expect_equal(36, length(list_ref_pop()))
-
-})
-
-# get_ref_pop() ----
-test_that('get_ref_pop',{
-
-  temp.pop <- get_ref_pop("2000 U.S. Std Population (19 age groups - Census P25-1130)")
-
-  expect_equal(19, nrow(temp.pop))
-
-  expect_equal(5, ncol(temp.pop))
-
-  expect_equal(c("age_end", "age_start", "agecat", "pop", "ref_pop_name"), sort(names(temp.pop)))
-
-})
-
 # adjust_direct() ----
 test_that('adjust_direct',{
 
@@ -123,6 +91,70 @@ test_that('age_standardize',{
   expect_warning(age_standardize(copy(temp.dt3)[1, count := pop + 1], my.count = "count", my.pop = "pop"))
 
   })
+
+# format_time() ----
+test_that('format_time',{
+
+  expect_equal('2010', format_time(2010))
+
+  expect_equal('2000, 2014-2016, 3000, 3002-4000', format_time(c(2000, 2014:2016, 3000, 3002:4000)))
+
+  expect_equal('2000, 2014-2016, 3000, 3002-4000', format_time(c(3002:4000, 2000, 2014:2016, 3000)))
+
+
+})
+
+# get_ref_pop() ----
+test_that('get_ref_pop',{
+
+  temp.pop <- get_ref_pop("2000 U.S. Std Population (19 age groups - Census P25-1130)")
+
+  expect_equal(19, nrow(temp.pop))
+
+  expect_equal(5, ncol(temp.pop))
+
+  expect_equal(c("age_end", "age_start", "agecat", "pop", "ref_pop_name"), sort(names(temp.pop)))
+
+})
+
+# list_ref_pop() ----
+test_that('list_ref_pop',{
+
+  expect_equal(36, length(list_ref_pop()))
+
+})
+
+# lossless_convert() ----
+test_that('lossless_convert', {
+  expect_equal(class(lossless_convert(c('1', '2', '3'), 'integer')), 'integer')
+
+  expect_equal(
+    expect_message(
+      lossless_convert(c('one', '2', '3'), 'integer'),
+      'would introduce additional NAs'),
+    c('one', '2', '3'))
+
+  expect_equal(
+    expect_message(
+      lossless_convert(c('1', '2', 'three'), 'integer'),
+      'would introduce additional NAs'),
+    c('1', '2', 'three'))
+
+  expect_equal(class(lossless_convert(c('2020-01-01', '2021-12-31', '2022-02-22'), 'Date')), 'Date')
+
+  expect_equal(
+    expect_message(
+      lossless_convert(c('2020-01-01', '2021-12-31', 'z'), 'Date'),
+    'would introduce additional NAs'),
+  c('2020-01-01', '2021-12-31', 'z'))
+
+  expect_equal(
+    expect_message(
+      lossless_convert(c('z', '2020-01-01', '2021-12-31'), 'Date'),
+    'would introduce additional NAs'),
+  c('z', '2020-01-01', '2021-12-31'))
+
+})
 
 # std_error() ----
 test_that('std_error',{


### PR DESCRIPTION
- validate_yaml_data now creates one unified warning
- updated lossless convert to prevent duplication of functions: had a copy inside validate_yaml_data and another stand-alone. The stand-alone is improved and is now called upon by validate_yaml_data
- updated relevant helpfiles
- added a few tests for lossless convert