### PR TITLE
Tsql validate bit fix

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -2085,7 +2085,7 @@ tsql_validate_field_types <- function(ph.data = NULL,
 
   # Define type compatibility and constraints ----
       type_compatibility <- list(
-        integer = c("tinyint", "smallint", "int", "bigint"),
+        integer = c("tinyint", "smallint", "int", "bigint", "bit"),
         numeric = c("tinyint", "smallint", "int", "bigint", "decimal", "numeric", "float", "real", "money", "smallmoney"),
         character = c("char", "varchar", "text", "nchar", "nvarchar", "ntext"),
         factor = c("char", "varchar", "text", "nchar", "nvarchar", "ntext"),
@@ -2127,6 +2127,8 @@ tsql_validate_field_types <- function(ph.data = NULL,
               } else {
                 TRUE # if R_type not numeric, must be integer -- defined in type compatibility
               }
+          } else if (tsql_type == "bit" && R_type == "integer") {
+            all(column %in% c(0, 1, NA), na.rm = TRUE)
           } else if (tsql_type %in% c("char", "varchar", "nchar", "nvarchar") && !is.na(size)) {
             all(nchar(as.character(column)) <= size, na.rm = TRUE)
           } else {


### PR DESCRIPTION
Straightforward fix allowing binary integers in R {`0L`, `1L`} to pass validation for pushing to SQL as `bit`.