### PR TITLE
Age standardize diagnostic

### DIFF
--- a/R/chars_functions.R
+++ b/R/chars_functions.R
@@ -231,7 +231,7 @@ chars_injury_matrix_count<- function(ph.data = NULL,
         if(nrow(setDT(quiet(list_dataset_columns('chars')))[grepl('^intent_', var.names)]) >
            length(grep('^intent_', names(ph.data), value = T))){
           mi_col_intent <- setdiff(setDT(list_dataset_columns('chars'))[grepl('^intent_', var.names)]$var.names, grep('^intent_', names(ph.data), value = T))
-          warning(paste0("\n\U00026A0 ph.data is missing the following `intent_**` columns: ", paste0(mi_col_intent, collapse = ', '), ". This may impact the completeness of your results."))
+          warning(paste0("\n\u26A0\ufe0f ph.data is missing the following `intent_**` columns: ", paste0(mi_col_intent, collapse = ', '), ". This may impact the completeness of your results."))
         }
 
     # mechanism ----
@@ -245,7 +245,7 @@ chars_injury_matrix_count<- function(ph.data = NULL,
         if(nrow(setDT(quiet(list_dataset_columns('chars')))[grepl('^mechanism_', var.names)]) >
            length(grep('^mechanism_', names(ph.data), value = T))){
           mi_col_mechanism <- setdiff(setDT(list_dataset_columns('chars'))[grepl('^mechanism_', var.names)]$var.names, grep('^mechanism_', names(ph.data), value = T))
-          warning(paste0("\n\U00026A0 ph.data is missing the following `mechanism_**` columns: ", paste0(mi_col_mechanism, collapse = ', '), ". This may impact the completeness of your results."))
+          warning(paste0("\n\u26A0\ufe0f ph.data is missing the following `mechanism_**` columns: ", paste0(mi_col_mechanism, collapse = ', '), ". This may impact the completeness of your results."))
         }
 
     # group_by ----
@@ -768,7 +768,7 @@ chars_icd_ccs_count <- function(ph.data = NULL,
         ph.data[, (icdcol) := toupper(get(icdcol))]
 
         if(length(grep("\\.|-", ph.data[[icdcol]], value = T) >0 )){
-          warning(paste0("\U00026A0 There is at least one row where `icdcol` (",
+          warning(paste0("\u26A0\ufe0f There is at least one row where `icdcol` (",
           icdcol, ") contains a hyphen (-), period (.), space or some other ",
           "non alpha-numeric character. These characters will be deleted, e.g., ",
           "A85.2 will become A852. This is necessary because causeids in ",
@@ -780,7 +780,7 @@ chars_icd_ccs_count <- function(ph.data = NULL,
         if(icdcm_version == 10){
           if(nrow(ph.data[is.na(get(icdcol)) | !grepl("^[A-Z][0-9]", get(icdcol))]) > 0){
             problem.icds <- ph.data[is.na(get(icdcol)) | !grepl("^[A-Z][0-9]", get(icdcol)), ][[icdcol]]
-            warning(paste0("\U00026A0 There is/are ", length(problem.icds), " row(s) where `icdcol` (",
+            warning(paste0("\u26A0\ufe0f There is/are ", length(problem.icds), " row(s) where `icdcol` (",
             icdcol, ") does not follow the proper ICD-10-CM pattern. All ICD-10-CMs that do not begin with a ",
             "single capital letter followed by a number have been replaced with NA."))
             ph.data[!grepl("^[A-Z][0-9]", get(icdcol)) , paste0(icdcol) := NA]

--- a/R/death_functions.R
+++ b/R/death_functions.R
@@ -437,7 +437,7 @@ death_icd10_clean <- function(icdcol){
 
   # Check for hyphens and periods which are sometimes present
   if(length(grep("\\.|-", icdcol, value = T) > 0 )){
-    warning(paste0("\n\U00026A0 There is at least one row where `icdcol` contains a hyphen (-), period (.), " ,
+    warning(paste0("\n\u26A0\ufe0f There is at least one row where `icdcol` contains a hyphen (-), period (.), " ,
                    "\nspace or some other non alpha-numeric character. These characters have been deleted, ",
                    "\ne.g., A85.2 will become A852. This is necessary because rads death functions expect",
                    "\npure alpha numeric ICD codes."
@@ -450,7 +450,7 @@ death_icd10_clean <- function(icdcol){
   problem.icds <- grep("^[A-Z].*[0-9]$", icdcol, value = TRUE, invert = TRUE)
   problem.icds <- problem.icds[!is.na(problem.icds)]
   if (length(problem.icds) > 0) {
-    warning(paste0("\n\U00026A0  There is/are ", length(problem.icds), " value(s) in `icdcol` that do not follow the proper ",
+    warning(paste0("\n\u26A0\ufe0f  There is/are ", length(problem.icds), " value(s) in `icdcol` that do not follow the proper ",
                    "\nICD pattern. All ICDs that do not begin with a letter and end with",
                    "\na numeric have been replaced with NA."))
     icdcol[!grepl("^[A-Z].*[0-9]$", icdcol)] <- NA
@@ -1524,7 +1524,7 @@ death_xxx_count <- function(ph.data,
       }
 
       if (!is.null(cause) & !is.null(causeids)){
-        message('\U00026A0 You specified both a cause and causeid argument. The causes will replace the causeids.')
+        message('\u26A0\ufe0f You specified both a cause and causeid argument. The causes will replace the causeids.')
         causeids <- NULL
         }
 
@@ -1734,7 +1734,7 @@ death_xxx_count <- function(ph.data,
   # Message about COVID-19 if selected causeid 17 ----
     if (nchsnum == 113 && 17 %in% x_combo$causeid) {
       message(
-        "\U00026A0 You selected causeid == 17 (Other and unspecified infectious and parasitic diseases...).
+        "\u26A0\ufe0f You selected causeid == 17 (Other and unspecified infectious and parasitic diseases...).
             COVID-19 (U07.1) has been EXCLUDED from this cause, following the example of WA DOH. Note
             however that, as of October 2020, CDC INCLUDES COVID-19 (U07.1) in causeid == 17. In
             other words, APDE followed WA DOH's decision since we provide a separate row for COVID-19."
@@ -2064,7 +2064,7 @@ life_table <- function(ph.data,
       if(nrow(ph.data[grepl('[0-9]+', get(myages)) & mx == 0]) > 0){
 
         warning(paste0(
-          "\n\U00026A0",
+          "\n\u26A0\ufe0f",
           "\nWarning: Zero deaths detected in one or more oldest age groups (e.g., `", myages, "==", unique(ph.data[istart == max(istart)][[myages]]), "`).",
           "\nThis may indicate an error in data preparation or reflect small population sizes.\n",
           "\nThe function has provided modeled `mx` values, affecting `Tx` and `ex` calculations,",
@@ -2159,7 +2159,7 @@ life_table <- function(ph.data,
       fill_variance <- function(ph.data.sub){
         obs.variances <- sort(ph.data.sub[!is.nan(qx_variance) & qx_variance != 0]$qx_variance)
         if(length(obs.variances) < 0.5*nrow(ph.data.sub)){
-          warning(paste0("\U00026A0 You have ", nrow(ph.data.sub[is.nan(qx_variance)]), " rows where the variance of the probability of dying in the interval is NaN, probably due to zero deaths.",
+          warning(paste0("\u26A0\ufe0f You have ", nrow(ph.data.sub[is.nan(qx_variance)]), " rows where the variance of the probability of dying in the interval is NaN, probably due to zero deaths.",
                          "\n This is more than 50% of your age groups, which means your population is likely too small for meaningful life expectancy calculations.",
                          "\n The variances will be filled with the median of the measured variances, but be cautious in using / interpreting the estimates.",
                          "\n If this message is repeated, it is because this problem occurs in more than one of your tables defined by the `group_by` argument."))
@@ -2505,13 +2505,13 @@ life_table_prep <- function(ph.data,
       ph.data <- data.table::setDT(data.table::copy(ph.data)) # to prevent changing of original by reference
 
       if(length(intersect(c("start", "end", "dob", "dod"), names(ph.data))) > 1){
-        warning("\n\U00026A0 ph.data has a column named 'start', 'end', 'dob', or 'dod' which was overwritten by this function. \nTo preserve your columns, rename them, and run this function again.")}
+        warning("\n\u26A0\ufe0f ph.data has a column named 'start', 'end', 'dob', or 'dod' which was overwritten by this function. \nTo preserve your columns, rename them, and run this function again.")}
 
     # cuts ----
       if(isTRUE(any(is.na(cuts))) || is.null(cuts) || !is.numeric(cuts)){stop("\n\U0001f47f 'cuts' must be specified as a numeric vector and cannot contain any NA's.")}
       if(length(cuts) <= 1){stop("\n\U0001f47f 'cuts' should be a numeric vector of length >1 and typically of length ~20.")}
       if(min(cuts) < 0){stop("\n\U0001f47f The minimum age in 'cuts' should be zero.")}
-      if(max(cuts) > 100){warning("\n\U00026A0 You're maximum age in 'cuts' is greater than 100. \nYou do not have to change this, but know that ages are top coded at 100.")}
+      if(max(cuts) > 100){warning("\n\u26A0\ufe0f You're maximum age in 'cuts' is greater than 100. \nYou do not have to change this, but know that ages are top coded at 100.")}
 
     # dobvar ----
       if(dobvar == "dobvar"){
@@ -2526,7 +2526,7 @@ life_table_prep <- function(ph.data,
       if(!dodvar %in% names(ph.data)){stop("\n\U0001f47f 'dodvar' must specify the name of a date of death column that exists in ph.data.")}
 
       if(nrow(ph.data[get(dodvar) < get(dobvar)]) > 0){
-        warning(paste0("\n\U00026A0 There are ", nrow(ph.data[dodvar < dobvar]), " rows where 'dodvar' is less than 'dobvar'. \nThese date pairs had their values set to NA and will only contribute indirectly to the life_table calculations."))
+        warning(paste0("\n\u26A0\ufe0f There are ", nrow(ph.data[dodvar < dobvar]), " rows where 'dodvar' is less than 'dobvar'. \nThese date pairs had their values set to NA and will only contribute indirectly to the life_table calculations."))
         ph.data[get(dodvar) < get(dobvar), paste0(dodvar) := NA]
         ph.data[get(dodvar) < get(dobvar), paste0(dobvar) := NA]
       }
@@ -2547,8 +2547,8 @@ life_table_prep <- function(ph.data,
     # confirm that dob and dod are legitimate
     dob_na <- nrow(ph.data[is.na(dob)])/nrow(ph.data)
     dod_na <- nrow(ph.data[is.na(dod)])/nrow(ph.data)
-    if(dob_na > 0.01){warning("\n\U00026A0 More than 1% of the date of birth values are missing. \nPlease check that your variable is of class Date or is of class character in the form 'YYYY-MM-DD' or 'YYYY/MM/DD'. \nDeaths with unknown dob will be distributed proportionately among deaths with known dates of birth.")}
-    if(dod_na > 0.01){warning("\n\U00026A0 More than 1% of the date of death values are missing. \nPlease check that your variable is of class Date or is of class character in the form 'YYYY-MM-DD' or 'YYYY/MM/DD'.")}
+    if(dob_na > 0.01){warning("\n\u26A0\ufe0f More than 1% of the date of birth values are missing. \nPlease check that your variable is of class Date or is of class character in the form 'YYYY-MM-DD' or 'YYYY/MM/DD'. \nDeaths with unknown dob will be distributed proportionately among deaths with known dates of birth.")}
+    if(dod_na > 0.01){warning("\n\u26A0\ufe0f More than 1% of the date of death values are missing. \nPlease check that your variable is of class Date or is of class character in the form 'YYYY-MM-DD' or 'YYYY/MM/DD'.")}
 
   # Properly calculate age at death ----
     ph.data[, death_age := rads::calc_age(dob, dod)]

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -229,7 +229,7 @@ age_standardize <- function (ph.data,
 
     # check for ages > 100 ----
     if(nrow(ph.data[age > 100]) > 0){
-      warning(paste0("\n\U00026A0 ph.data (", ph.data.name, ") contains at least one row where age is greater than 100.\n",
+      warning(paste0("\n\u26A0\ufe0f ph.data (", ph.data.name, ") contains at least one row where age is greater than 100.\n",
                      "Those values have been recoded to 100 because population pulled from\n",
                      "get_population() is top coded to 100 and reference populations are usually top coded at 85."),
               immediate. = TRUE, call. = FALSE)
@@ -253,7 +253,7 @@ age_standardize <- function (ph.data,
     if (is.null(group_by)) {
       check_result <- check_full_age_range(ph.data)
       if (!check_result$full_range) {
-        warning(paste0("\n\U00026A0 ph.data (", ph.data.name, ") does not have the full range of ages from 0 to 100.\n",
+        warning(paste0("\n\u26A0\ufe0f ph.data (", ph.data.name, ") does not have the full range of ages from 0 to 100.\n",
                        "Missing ages: ", format_time(check_result$missing), "\n",
                        "This may affect the accuracy of your age-adjusted rates.\n",
                        "Consider adding missing ages with zero counts and the appropriate population."),
@@ -278,7 +278,7 @@ age_standardize <- function (ph.data,
         table_output <- paste(capture.output(print(age_chk, row.names = FALSE, class = FALSE, print.keys = FALSE)), collapse = "\n")
 
         warning_message <- paste0(
-          "\n\U00026A0 Missing ages detected in ", ph.data.name, " for these groups:\n\n",
+          "\n\u26A0\ufe0f Missing ages detected in ", ph.data.name, " for these groups:\n\n",
           table_output,
           "\n\nThis may affect the accuracy of your age-adjusted rates.\n",
           "Consider adding missing ages with zero counts and the appropriate population."
@@ -289,7 +289,7 @@ age_standardize <- function (ph.data,
 
       if (nrow(age_chk) > 6) {
         warning_message <- paste0(
-          "\n\U00026A0 Missing ages detected in ", ph.data.name, " for ",
+          "\n\u26A0\ufe0f Missing ages detected in ", ph.data.name, " for ",
           format(nrow(age_chk), big.mark = ','), " groups.\n",
           "This may affect the accuracy of your age-adjusted rates.\n",
           "Consider adding missing ages with zero counts and the appropriate population.\n",
@@ -312,7 +312,7 @@ age_standardize <- function (ph.data,
 
   # Check count ----
   if(nrow(ph.data[is.na(count)]) > 0){
-    warning(paste0("\U00026A0 ph.data (", ph.data.name, ") contains at least one row where my.count is missing.
+    warning(paste0("\u26A0\ufe0f ph.data (", ph.data.name, ") contains at least one row where my.count is missing.
                     Those values have been replaced with zero."))
     ph.data[is.na(count), count := 0]
   }
@@ -333,7 +333,7 @@ age_standardize <- function (ph.data,
 
   # Check count vs population ----
   if(nrow(ph.data[count > pop]) > 0 ){
-    warning(paste0("\U00026A0 ph.data (", ph.data.name, ") contains at least one row where the count is greater than the population.
+    warning(paste0("\u26A0\ufe0f ph.data (", ph.data.name, ") contains at least one row where the count is greater than the population.
                         This may be correct because OFM populations are just estimates. However, you are encouraged to check the data."))
   }
 
@@ -359,7 +359,7 @@ age_standardize <- function (ph.data,
 
   # Hack when pop < count in age collapsed data ----
   if(nrow(ph.data[pop < count]) > 0){
-    warning(paste0("\U00026A0
+    warning(paste0("\u26A0\ufe0f
       When ph.data (", ph.data.name, ") was collapsed to match the standard
       population, the aggregate `count` was greater than the aggreate `pop` for
       the following age group(s): ",
@@ -915,7 +915,7 @@ convert_to_date <- function(x, origin = "1899-12-30") {
                                             "%d %B, %Y", "%Y-%m-%d %H:%M:%S",
                                             "%Y/%m/%d %H:%M:%S"))))
     if (all(is.na(date_out))) {
-      warning('\n\U00026A0 `', x_name, '` cannot be converted to a date. Your original data will be returned.')
+      warning('\n\u26A0\ufe0f `', x_name, '` cannot be converted to a date. Your original data will be returned.')
       return(x_orig)
     } else {return(date_out)}
   }
@@ -2109,7 +2109,7 @@ multi_t_test <- function(means,
         stop("\n\U1F6D1 'n' must be a numeric vector of positive values.")
       }
       if (any(n < 30)) {
-        warning("\n\U00026A0 Some sample sizes are below 30. ",
+        warning("\n\u26A0\ufe0f Some sample sizes are below 30. ",
                 "Results may be unreliable, especially with the 'estimated' df_method. ",
                 "Consider using a different df_method if appropriate.")
       }
@@ -2154,17 +2154,17 @@ multi_t_test <- function(means,
       # falls within 2 SD of the mean in a normal distribution
       estimated_sd <- (max(means) - min(means)) / 4
       n <- round((estimated_sd / ses)^2)
-      warning("\U00026A0 Sample sizes are estimated from standard errors and the range of means.\n",
+      warning("\u26A0\ufe0f Sample sizes are estimated from standard errors and the range of means.\n",
               "Use with caution. ", "Please provide the sample sizes {`n`} if known.")
 
       if (k < 10) {
-        warning("\n\U00026A0 The number of groups is small (< 10). ",
+        warning("\n\u26A0\ufe0f The number of groups is small (< 10). ",
                 "This may affect the reliability of estimated sample sizes.\n",
                 "Consider providing actual sample sizes if available.")
       }
 
       if (any(n < 30)) {
-        warning("\n\U00026A0 Some estimated sample sizes are below 30. ",
+        warning("\n\u26A0\ufe0f Some estimated sample sizes are below 30. ",
                 "Results may be unreliable, especially with the 'estimated' df_method. ",
                 "Consider using actual sample sizes or a different df_method.")
       }
@@ -2620,7 +2620,7 @@ string_clean <- function(dat = NULL,
 sql_clean <- function(dat = NULL, stringsAsFactors = FALSE){
   .Deprecated("string_clean")
 
-  warning("\n\U00026A0 As a courtesy, `sql_clean` remains operational for the time being.\n",
+  warning("\n\u26A0\ufe0f As a courtesy, `sql_clean` remains operational for the time being.\n",
           "Good things don't last forever. \nPlease update your code.",
           immediate. = FALSE)
 
@@ -2655,7 +2655,7 @@ std_error <- function(x) {
     se <- sd(x, na.rm = TRUE) / sqrt(sum(!is.na(x))) # standard error or mean is sd / sqrt(# samples)
 
     if (is.nan(se) || is.infinite(se)) {
-      warning("\n\U00026A0 Calculation resulted in NaN or Inf. Check your input data.")
+      warning("\n\u26A0\ufe0f Calculation resulted in NaN or Inf. Check your input data.")
     }
 
     return(se)
@@ -2944,7 +2944,7 @@ tsql_validate_field_types <- function(ph.data = NULL,
       # report if column is all NA
       na_cols <- ph.data[, lapply(.SD, function(x) all(is.na(x))), .SDcols = names(ph.data)]
       na_cols <- names(na_cols)[as.logical(na_cols)]
-      if(length(na_cols) > 0){warning('\U00026A0 Validation may be flawed for the following variables because they are 100% missing: ', paste0(na_cols, collapse = ', '))}
+      if(length(na_cols) > 0){warning('\u26A0\ufe0f Validation may be flawed for the following variables because they are 100% missing: ', paste0(na_cols, collapse = ', '))}
 
       # report back overall validation
       if (all(validation_results$is_valid)) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -251,7 +251,7 @@ age_standardize <- function (ph.data,
 
       }
     } else {
-      age_chk = ph.data[, list(complete = all(1:100 %in% age), missing = list(setdiff(1:100, age))), by = group_by]
+      age_chk = ph.data[, list(complete = all(0:100 %in% age), missing = list(setdiff(0:100, age))), by = group_by]
       age_chk = age_chk[complete == F]
       age_chk[, id := .I]
       if (length(age_chk) > 0) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -98,6 +98,7 @@ adjust_direct <- function(count, pop, stdpop, per = 100000, conf.level = 0.95) {
 #' @param per Integer vector of length 1. A multiplier for all rates and CI, e.g., when per = 1000, the rates are per 1000 people
 #' @param conf.level A numeric vector of length 1. The confidence interval used in the calculations.
 #' @param group_by Character vector of indeterminate length. By which variable(s) do you want to stratify the rate results, if any?
+#' @param diagnostic_report if group_by is used and there are groups with missing ages, return diagnostic report instead of normal results
 #'
 #' @return a data.table of the count, rate & adjusted rate with CIs, name of the reference population and the 'group_by' variable(s) -- if any
 #' @export
@@ -135,234 +136,233 @@ age_standardize <- function (ph.data,
                              my.pop = "pop",
                              per = 100000,
                              conf.level = 0.95,
-                             group_by = NULL)
-{
+                             group_by = NULL,
+                             diagnostic_report = F) {
   # Global variables used by data.table declared as NULL here to play nice with devtools::check() ----
-    ph.data.name <- age <- age_start <- age_end <- agecat <- count <- pop <-
-      stdpop <- reference_pop <- adj.lci <- adj.uci <- complete <- id <- NULL
+  ph.data.name <- age <- age_start <- age_end <- agecat <- count <- pop <-
+    stdpop <- reference_pop <- adj.lci <- adj.uci <- complete <- id <- NULL
 
-    ph.data.name <- deparse(substitute(ph.data))
-    ph.data <- copy(ph.data)
+  ph.data.name <- deparse(substitute(ph.data))
+  ph.data <- copy(ph.data)
 
   # Logic checks ----
-    # Check that ph.data is a data.frame or data.table ----
-      if( inherits(ph.data, "data.frame") == FALSE){stop("\n\U1F6D1 ph.data must be a data.frame or a data.table containing both counts and population data.")}
-      if( inherits(ph.data, "data.table") == FALSE){setDT(ph.data)}
+  # Check that ph.data is a data.frame or data.table ----
+  if( inherits(ph.data, "data.frame") == FALSE){stop("\n\U1F6D1 ph.data must be a data.frame or a data.table containing both counts and population data.")}
+  if( inherits(ph.data, "data.table") == FALSE){setDT(ph.data)}
 
-    # Check that ph.data has either 'age' or 'agecat' ----
-      age_exists <- "age" %in% names(ph.data)
-      agecat_exists <- "agecat" %in% names(ph.data)
+  # Check that ph.data has either 'age' or 'agecat' ----
+  age_exists <- "age" %in% names(ph.data)
+  agecat_exists <- "agecat" %in% names(ph.data)
 
-      if (age_exists && agecat_exists) {
-        stop("\n\U1F6D1 Both 'age' and 'agecat' columns are present, but only one is needed. Please check your data.")
-      } else if (!age_exists && !agecat_exists) {
-        stop("\n\U1F6D1 Neither 'age' nor 'agecat' columns are present. Please check your data.")
-      } else if (age_exists) {
-        # Check if 'age' is integer or can be converted to integer without loss
-        if (!is.integer(ph.data$age) & is.numeric(ph.data$age)) {
-          if (all(ph.data$age == floor(ph.data$age))) {
-            ph.data[, age := as.integer(age)]
-          } else {
-          stop("\n\U1F6D1 The 'age' column is not an integer and cannot be converted to integer without loss of data.")
-          }
-        }
-      } else if (agecat_exists) {
-        # Check if 'agecat' is character or factor
-        if (!is.character(ph.data$agecat)) {
-          if (is.factor(ph.data$agecat)) {
-            ph.data[, agecat := as.character(agecat)]
-          } else {
-            stop("\n\U1F6D1 The 'agecat' column is neither character nor factor.")
-          }
-        }
+  if (age_exists && agecat_exists) {
+    stop("\n\U1F6D1 Both 'age' and 'agecat' columns are present, but only one is needed. Please check your data.")
+  } else if (!age_exists && !agecat_exists) {
+    stop("\n\U1F6D1 Neither 'age' nor 'agecat' columns are present. Please check your data.")
+  } else if (age_exists) {
+    # Check if 'age' is integer or can be converted to integer without loss
+    if (!is.integer(ph.data$age) & is.numeric(ph.data$age)) {
+      if (all(ph.data$age == floor(ph.data$age))) {
+        ph.data[, age := as.integer(age)]
+      } else {
+        stop("\n\U1F6D1 The 'age' column is not an integer and cannot be converted to integer without loss of data.")
       }
+    }
+  } else if (agecat_exists) {
+    # Check if 'agecat' is character or factor
+    if (!is.character(ph.data$agecat)) {
+      if (is.factor(ph.data$agecat)) {
+        ph.data[, agecat := as.character(agecat)]
+      } else {
+        stop("\n\U1F6D1 The 'agecat' column is neither character nor factor.")
+      }
+    }
+  }
 
-    # Check arguments needed for adjust_direct ----
-      if(! my.count %in% colnames(ph.data)){
-        stop(paste0("\n\U1F6D1 The column '", my.count, "' does not exist in ph.data.\n",
-                    "ph.data must have a column indicating the count of events (e.g., deaths, births, etc.) and is typically named 'count'.\n",
-                    "If such a column exists with a different name, you need to specify it in the `my.count` argument. e.g., my.count = 'deaths'."))
-        }
+  # Check arguments needed for adjust_direct ----
+  if(! my.count %in% colnames(ph.data)){
+    stop(paste0("\n\U1F6D1 The column '", my.count, "' does not exist in ph.data.\n",
+                "ph.data must have a column indicating the count of events (e.g., deaths, births, etc.) and is typically named 'count'.\n",
+                "If such a column exists with a different name, you need to specify it in the `my.count` argument. e.g., my.count = 'deaths'."))
+  }
 
-      if(! my.pop %in% colnames(ph.data)){
-        stop(paste0("\n\U1F6D1 The column '", my.pop, "' does not exist in ph.data.\n",
-                    "ph.data must have a column for the population denominator correspondnig to the given demographics. It is typically named 'pop'.\n",
-                    "If such a column exists with a different name, you need to specify it in the `my.pop` argument. e.g., my.pop = 'wapop'."))
-        }
+  if(! my.pop %in% colnames(ph.data)){
+    stop(paste0("\n\U1F6D1 The column '", my.pop, "' does not exist in ph.data.\n",
+                "ph.data must have a column for the population denominator correspondnig to the given demographics. It is typically named 'pop'.\n",
+                "If such a column exists with a different name, you need to specify it in the `my.pop` argument. e.g., my.pop = 'wapop'."))
+  }
 
-    # Ensure the reference population exists ----
-      if(is.null(ref.popname)){ref.popname <- "2000 U.S. Std Population (11 age groups)"}
-      if(! ref.popname %in% c( list_ref_pop(), "none")){
-        stop(strwrap(paste0("\n\U1F6D1 ref.popname ('", ref.popname, "') is not a valid reference population name.
+  # Ensure the reference population exists ----
+  if(is.null(ref.popname)){ref.popname <- "2000 U.S. Std Population (11 age groups)"}
+  if(! ref.popname %in% c( list_ref_pop(), "none")){
+    stop(strwrap(paste0("\n\U1F6D1 ref.popname ('", ref.popname, "') is not a valid reference population name.
               The names of standardized reference populations can be viewed by typing `list_ref_pop()`.
               If ph.data is already aggregated/collapsed and has a relevant 'stdpop' column, please set ref.popname = 'none'"), prefix = " ", initial = ""))}
 
-      if(ref.popname == "none" & !"stdpop" %in% colnames(ph.data)){stop("\n\U1F6D1 When specifying ref.popname = 'none', ph.data must have a column named 'stdpop' with the reference standard population data.")}
+  if(ref.popname == "none" & !"stdpop" %in% colnames(ph.data)){stop("\n\U1F6D1 When specifying ref.popname = 'none', ph.data must have a column named 'stdpop' with the reference standard population data.")}
 
-      if(ref.popname == "none" & collapse == T){stop(strwrap("\n\U1F6D1 When ref.popname = 'none', collapse should equal F.
+  if(ref.popname == "none" & collapse == T){stop(strwrap("\n\U1F6D1 When ref.popname = 'none', collapse should equal F.
                                                                       Selecting ref.popname = 'none' expects that ph.data has already been collapsed/aggregated and has a 'stdpop' column."), prefix = " ", initial = "")}
 
   # Standardize column names ----
-    # purposefully did not use setnames() because it is possible that count | pop already exists and are intentionally using different columns for this function
-      ph.data[, "count" := get(my.count)]
-      ph.data[, "pop" := get(my.pop)]
+  # purposefully did not use setnames() because it is possible that count | pop already exists and are intentionally using different columns for this function
+  ph.data[, "count" := get(my.count)]
+  ph.data[, "pop" := get(my.pop)]
 
   # Check ranges for age, count, and population ----
-    # Check age ----
-      if(!"agecat" %in% names(ph.data)){ # if given agecat, ignore these tests for single years of age
-        # check for missing ages ----
-          if(nrow(ph.data[is.na(age)]) > 0){
-            stop(paste0("\n\U1F6D1 ph.data (", ph.data.name, ") contains at least one row where age is missing.\nCorrect the data and try again."))
-          }
+  # Check age ----
+  if(!"agecat" %in% names(ph.data)){ # if given agecat, ignore these tests for single years of age
+    # check for missing ages ----
+    if(nrow(ph.data[is.na(age)]) > 0){
+      stop(paste0("\n\U1F6D1 ph.data (", ph.data.name, ") contains at least one row where age is missing.\nCorrect the data and try again."))
+    }
 
-        # check for ages > 100 ----
-          if(nrow(ph.data[age > 100]) > 0){
-            warning(paste0("\n\U00026A0 ph.data (", ph.data.name, ") contains at least one row where age is greater than 100.\n",
-                           "Those values have automatically been recoded to 100 because population pulled from\n",
-                           "get_population() is top coded to 100 and reference populations are usually top coded at 85."),
-                    immediate. = TRUE, call. = FALSE)
-            ph.data[age > 100, age := 100]
-          }
+    # check for ages > 100 ----
+    if(nrow(ph.data[age > 100]) > 0){
+      warning(paste0("\n\U00026A0 ph.data (", ph.data.name, ") contains at least one row where age is greater than 100.\n",
+                     "Those values have automatically been recoded to 100 because population pulled from\n",
+                     "get_population() is top coded to 100 and reference populations are usually top coded at 85."),
+              immediate. = TRUE, call. = FALSE)
+      ph.data[age > 100, age := 100]
+    }
 
-        # check for negative ages ----
-          if(nrow(ph.data[age < 0]) > 0){
-            stop(paste0("\n\U1F6D1 ph.data (", ph.data.name, ") contains at least one row where age is negative.\nCorrect the data and try again."))
-          }
+    # check for negative ages ----
+    if(nrow(ph.data[age < 0]) > 0){
+      stop(paste0("\n\U1F6D1 ph.data (", ph.data.name, ") contains at least one row where age is negative.\nCorrect the data and try again."))
+    }
 
-        # Check for full range of ages (0 to 100) overall and within groups ----
-          # simple function to check whether all ages are present (T | F) and which ones are missing (if any)
-            check_full_age_range <- function(tempx) {
-              actual_ages <- sort(unique(tempx$age))
-              missing_ages <- setdiff(0:100, actual_ages)
-              return(list(full_range = length(missing_ages) == 0, missing = missing_ages))
-            }
+    # Check for full range of ages (0 to 100) overall and within groups ----
+    # simple function to check whether all ages are present (T | F) and which ones are missing (if any)
+    check_full_age_range <- function(tempx) {
+      actual_ages <- sort(unique(tempx$age))
+      missing_ages <- setdiff(0:100, actual_ages)
+      return(list(full_range = length(missing_ages) == 0, missing = missing_ages))
+    }
 
-          # Simple check when group_by not specified
-          if (is.null(group_by)) {
-            check_result <- check_full_age_range(ph.data)
-            if (!check_result$full_range) {
-              warning(paste0("\n\U00026A0 ph.data (", ph.data.name, ") does not have the full range of ages from 0 to 100.\n",
-                             "Missing ages: ", paste(check_result$missing, collapse = ", "), "\n",
-                             "This may affect the accuracy of your age-adjusted rates.\n",
-                             "Consider adding missing ages with zero counts and the appropriate population."),
-                      immediate. = TRUE, call. = FALSE)
-            }
-          } else {
+    # Simple check when group_by not specified
 
-            age_chk = ph.data[, list(complete = all(1:100 %in% age), missing = list(setdiff(1:100, age))), by = group_by]
-            age_chk = age_chk[complete == F]
-            age_chk[, id := .I]
-            age_chk = split(age_chk, by = 'id')
+    if (is.null(group_by)) {
+      check_result <- check_full_age_range(ph.data)
+      if (!check_result$full_range) {
+        warning(paste0("\n\U00026A0 ph.data (", ph.data.name, ") does not have the full range of ages from 0 to 100.\n",
+                       "Missing ages: ", paste(check_result$missing, collapse = ", "), "\n",
+                       "This may affect the accuracy of your age-adjusted rates.\n",
+                       "Consider adding missing ages with zero counts and the appropriate population."),
+                immediate. = TRUE, call. = FALSE)
 
+      }
+    } else {
+      age_chk = ph.data[, list(complete = all(1:100 %in% age), missing = list(setdiff(1:100, age))), by = group_by]
+      age_chk = age_chk[complete == F]
+      age_chk[, id := .I]
+      if (length(age_chk) > 0) {
+        warning_message <- paste0("\n\U00026A0 multiple groups in ph.data (", ph.data.name, ") do not have the full range of ages from 0 to 100:\n",
+                                  "This may affect the accuracy of your age-adjusted rates.\n",
+                                  "Consider adding missing ages with zero counts and the appropriate population.\n",
+                                  "Rerun age_standardize(..., diagnostic_report = T) will return a table of affected groups and ages instead of the normal output.")
+      }
+      warning(warning_message, immediate. = TRUE, call. = FALSE)
 
-            if (length(age_chk) > 0) {
-              warning_message <- paste0("\n\U00026A0 Some groups in ph.data (", ph.data.name, ") do not have the full range of ages from 0 to 100:\n")
-              for (group in age_chk) { # identify issues one item of the list (i.e., one group combo) at a time
-                group_desc <- paste(group[, .SD, .SDcols = group_by], sep = "=", collapse = ", ")
-                warning_message <- paste0(warning_message,
-                                          "  Group (", group_desc, ") is missing ages: ",
-                                          paste(group$missing[[1]], collapse = ", "), "\n")
-              }
-              warning_message <- paste0(warning_message,
-                                        "This may affect the accuracy of your age-adjusted rates.\n",
-                                        "Consider adding missing ages with zero counts and the appropriate population.")
-              warning(warning_message, immediate. = TRUE, call. = FALSE)
-            }
-          }
+      if(diagnostic_report) {
+        return(age_chk)
       }
 
-    # Check agecat ----
-      if("agecat" %in% names(ph.data)){
-        if(!identical(sort(unique(ph.data$agecat)),
-                      sort(unique(get_ref_pop(ref.popname)[['agecat']])))){
-          stop("\n\U1F6D1 STOP and fix your code!\nThe agecat values in ph.data must match those in your reference \npopulation {",ref.popname, "} exactly.")
-        }
-      }
 
-    # Check count ----
-      if(nrow(ph.data[is.na(count)]) > 0){
-        warning(paste0("\U00026A0 ph.data (", ph.data.name, ") contains at least one row where my.count is missing.
+    }
+
+  }
+
+  # Check agecat ----
+  if("agecat" %in% names(ph.data)){
+    if(!identical(sort(unique(ph.data$agecat)),
+                  sort(unique(get_ref_pop(ref.popname)[['agecat']])))){
+      stop("\n\U1F6D1 STOP and fix your code!\nThe agecat values in ph.data must match those in your reference \npopulation {",ref.popname, "} exactly.")
+    }
+  }
+
+  # Check count ----
+  if(nrow(ph.data[is.na(count)]) > 0){
+    warning(paste0("\U00026A0 ph.data (", ph.data.name, ") contains at least one row where my.count is missing.
                     Those values have been replaced with zero."))
-        ph.data[is.na(count), count := 0]
-      }
-      if(nrow(ph.data[count < 0]) > 0){
-        stop(paste0("\U0001f47f ph.data (", ph.data.name, ") contains at least one row where my.count is negative.
+    ph.data[is.na(count), count := 0]
+  }
+  if(nrow(ph.data[count < 0]) > 0){
+    stop(paste0("\U0001f47f ph.data (", ph.data.name, ") contains at least one row where my.count is negative.
                         Correct the data and try again."))
-      }
+  }
 
-    # Check population ----
-      if(nrow(ph.data[is.na(pop)]) > 0){
-        stop(paste0("\U0001f47f ph.data (", ph.data.name, ") contains at least one row where my.pop is missing.
+  # Check population ----
+  if(nrow(ph.data[is.na(pop)]) > 0){
+    stop(paste0("\U0001f47f ph.data (", ph.data.name, ") contains at least one row where my.pop is missing.
                      Correct the data and try again."))
-      }
-      if(nrow(ph.data[pop < 0]) > 0){
-        stop(paste0("\U0001f47f ph.data (", ph.data.name, ") contains at least one row where my.pop is negative.
+  }
+  if(nrow(ph.data[pop < 0]) > 0){
+    stop(paste0("\U0001f47f ph.data (", ph.data.name, ") contains at least one row where my.pop is negative.
                         Correct the data and try again."))
-      }
+  }
 
-    # Check count vs population ----
-      if(nrow(ph.data[count > pop]) > 0 ){
-        warning(paste0("\U00026A0 ph.data (", ph.data.name, ") contains at least one row where the count is greater than the population.
+  # Check count vs population ----
+  if(nrow(ph.data[count > pop]) > 0 ){
+    warning(paste0("\U00026A0 ph.data (", ph.data.name, ") contains at least one row where the count is greater than the population.
                         This may be correct because OFM populations are just estimates. However, you are encouraged to check the data."))
-      }
+  }
 
   # Collapse ph.data to match standard population bins ----
-    if(collapse==T){
-      if(! "age" %in% colnames(ph.data)){stop(strwrap("\n\U1F6D1 When collapse = T, ph.data must have a column named 'age' where age is an integer.
+  if(collapse==T){
+    if(! "age" %in% colnames(ph.data)){stop(strwrap("\n\U1F6D1 When collapse = T, ph.data must have a column named 'age' where age is an integer.
                                                           This is necessary to generate age bins that align with the selected standard
                                                           reference population. If ph.data already has an 'agecat' column that is formatted
                                                           identically to that in the standard reference population, set collapse = F"), prefix = " ", initial = "")}
-      if(is.numeric(ph.data$age) == F){stop("\n\U1F6D1 When collapse = T, the 'age' column must be comprised entirely of integers")}
-      if(sum(as.numeric(ph.data$age) %% 1) != 0){stop("\n\U1F6D1 When collapse = T, the 'age' column must be comprised entirely of integers")}
-      if("agecat" %in% colnames(ph.data)){stop(strwrap("\n\U1F6D1 When collapse = T, a new column named 'agecat' is created to match that in the standard reference population.
+    if(is.numeric(ph.data$age) == F){stop("\n\U1F6D1 When collapse = T, the 'age' column must be comprised entirely of integers")}
+    if(sum(as.numeric(ph.data$age) %% 1) != 0){stop("\n\U1F6D1 When collapse = T, the 'age' column must be comprised entirely of integers")}
+    if("agecat" %in% colnames(ph.data)){stop(strwrap("\n\U1F6D1 When collapse = T, a new column named 'agecat' is created to match that in the standard reference population.
                                                     ph.data already has a column named 'agecat' and it will not be automatically overwritten.
                                                     If you are sure you want to create a new column named 'agecat', delete the existing column in ph.data and run again."),
                                              prefix = " ", initial = "")}
-      my.ref.pop <- get_ref_pop(ref.popname)
-      for(z in seq(1, nrow(my.ref.pop))){
-        ph.data[age %in% my.ref.pop[z, age_start]:my.ref.pop[z, age_end], agecat := my.ref.pop[z, agecat]]
-      }
-      if(!is.null(group_by)){ph.data <- ph.data[, list(count = sum(count), pop = sum(pop)), by = c("agecat", group_by)]}
-      if(is.null(group_by)){ph.data <- ph.data[, list(count = sum(count), pop = sum(pop)), by = "agecat"]}
+    my.ref.pop <- get_ref_pop(ref.popname)
+    for(z in seq(1, nrow(my.ref.pop))){
+      ph.data[age %in% my.ref.pop[z, age_start]:my.ref.pop[z, age_end], agecat := my.ref.pop[z, agecat]]
     }
+    if(!is.null(group_by)){ph.data <- ph.data[, list(count = sum(count), pop = sum(pop)), by = c("agecat", group_by)]}
+    if(is.null(group_by)){ph.data <- ph.data[, list(count = sum(count), pop = sum(pop)), by = "agecat"]}
+  }
 
   # Hack when pop < count in age collapsed data ----
-    if(nrow(ph.data[pop < count]) > 0){
-      warning(paste0("\U00026A0
+  if(nrow(ph.data[pop < count]) > 0){
+    warning(paste0("\U00026A0
       When ph.data (", ph.data.name, ") was collapsed to match the standard
       population, the aggregate `count` was greater than the aggreate `pop` for
       the following age group(s): ",
-      sort(paste(unique(ph.data[pop < count]$agecat), collapse = ', ')), ". In these rows, the
+                   sort(paste(unique(ph.data[pop < count]$agecat), collapse = ', ')), ". In these rows, the
       `pop` was ascribed the `count` value. This is necessary to calculate
       the age adjusted rate and only nomimally biases the calculated rates since
       the counts are typically small."))
 
-      ph.data[pop < count, pop := count]
-    }
+    ph.data[pop < count, pop := count]
+  }
 
   # Hack when pop == 0 ----
-    if(nrow(ph.data[pop ==0]) > 0){
-      ph.data[pop == 0, pop := 1]
-    }
+  if(nrow(ph.data[pop ==0]) > 0){
+    ph.data[pop == 0, pop := 1]
+  }
 
   # Merge standard pop onto count data ----
-    if(ref.popname != "none"){
-      ph.data <- merge(ph.data, get_ref_pop(ref.popname)[, list(agecat, stdpop = pop)], by = "agecat")
-    }
+  if(ref.popname != "none"){
+    ph.data <- merge(ph.data, get_ref_pop(ref.popname)[, list(agecat, stdpop = pop)], by = "agecat")
+  }
 
   # Calculate crude & adjusted rates with CI ----
-    if(!is.null(group_by)){my.rates <- ph.data[, as.list(adjust_direct(count = count, pop = pop, stdpop = stdpop, conf.level = as.numeric(conf.level), per = per)), by = group_by]}
-    if( is.null(group_by)){my.rates <- ph.data[, as.list(adjust_direct(count = count, pop = pop, stdpop = stdpop, conf.level = as.numeric(conf.level), per = per))]}
+  if(!is.null(group_by)){my.rates <- ph.data[, as.list(adjust_direct(count = count, pop = pop, stdpop = stdpop, conf.level = as.numeric(conf.level), per = per)), by = group_by]}
+  if( is.null(group_by)){my.rates <- ph.data[, as.list(adjust_direct(count = count, pop = pop, stdpop = stdpop, conf.level = as.numeric(conf.level), per = per))]}
 
   # Tidy results ----
-    rate_estimates <- c("crude.rate", "crude.lci", "crude.uci", "adj.rate", "adj.lci", "adj.uci")
-    my.rates[, c(rate_estimates) := lapply(.SD, rads::round2, 2), .SDcols = rate_estimates]
-    my.rates[, reference_pop := ref.popname]
-    my.rates[is.nan(adj.lci) & count == 0, adj.lci := 0]
-    if(ref.popname == "none"){my.rates[, reference_pop := paste0("stdpop column in `", ph.data.name, "`")]}
+  rate_estimates <- c("crude.rate", "crude.lci", "crude.uci", "adj.rate", "adj.lci", "adj.uci")
+  my.rates[, c(rate_estimates) := lapply(.SD, rads::round2, 2), .SDcols = rate_estimates]
+  my.rates[, reference_pop := ref.popname]
+  my.rates[is.nan(adj.lci) & count == 0, adj.lci := 0]
+  if(ref.popname == "none"){my.rates[, reference_pop := paste0("stdpop column in `", ph.data.name, "`")]}
 
   # Return object ----
-    return(my.rates)
+  return(my.rates)
 }
 
 # as_imputed_brfss() ----

--- a/man/age_standardize.Rd
+++ b/man/age_standardize.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utilities.R
 \name{age_standardize}
 \alias{age_standardize}
-\title{Calculate age standardized rates from a data.table with age, counts, and population columns. (Built on adjust_direct())}
+\title{Calculate age standardized rates from a data.table with age, counts, and population columns}
 \usage{
 age_standardize(
   ph.data,
@@ -12,26 +12,37 @@ age_standardize(
   my.pop = "pop",
   per = 100000,
   conf.level = 0.95,
-  group_by = NULL
+  group_by = NULL,
+  diagnostic_report = F
 )
 }
 \arguments{
 \item{ph.data}{a data.table or data.frame containing the data to be age-standardized.}
 
-\item{ref.popname}{Character vector of length 1. Only valid options are those in list_ref_pop() and
-"none" (when standard population already exists in ph.data)}
+\item{ref.popname}{Character vector of length 1. Only valid options are those
+in \code{\link{list_ref_pop}} and "none" (when standard population already exists in ph.data)}
 
-\item{collapse}{Logical vector of length 1. Do you want to collapse ph.data ages to match those in ref.popname?}
+\item{collapse}{Logical vector of length 1. Do you want to collapse ph.data ages
+to match those in \code{ref.popname}?}
 
-\item{my.count}{Character vector of length 1. Identifies the column with the count data aggregated by the given demographics.}
+\item{my.count}{Character vector of length 1. Identifies the column with the
+count data aggregated by the given demographics.}
 
-\item{my.pop}{Character vector of length 1. Identifies the column with the population corresponding to the given demographics.}
+\item{my.pop}{Character vector of length 1. Identifies the column with the
+population corresponding to the given demographics.}
 
-\item{per}{Integer vector of length 1. A multiplier for all rates and CI, e.g., when per = 1000, the rates are per 1000 people}
+\item{per}{Integer vector of length 1. A multiplier for all rates and CI, e.g.,
+when per = 1000, the rates are per 1000 people}
 
-\item{conf.level}{A numeric vector of length 1. The confidence interval used in the calculations.}
+\item{conf.level}{A numeric vector of length 1. The confidence interval used
+in the calculations.}
 
-\item{group_by}{Character vector of indeterminate length. By which variable(s) do you want to stratify the rate results, if any?}
+\item{group_by}{Character vector of indeterminate length. By which variable(s)
+do you want to stratify the rate results, if any?}
+
+\item{diagnostic_report}{If \code{group_by} is used and there are groups with missing ages,
+setting \code{diagnostic_report = TRUE} returns a diagnostic table instead of normal results.
+Use this option if a warning about missing age groups appears when running the function normally.}
 }
 \value{
 a data.table of the count, rate & adjusted rate with CIs, name of the reference population and the 'group_by' variable(s) -- if any
@@ -42,7 +53,7 @@ Calculate age standardized rates from a data.table with age, counts, and populat
 Your dataset must have the following three columns ...
 \itemize{
 \item 'age' or 'agecat': 'age' in single years (if collapse = T) or 'agecat' with the same age bins as your selected reference population (if collapse = F)
-\item an aggregated count for the event (e.g., disease) for which you want to find an age standardized rate
+\item an \bold{aggregated} count for the event (e.g., disease) for which you want to find an age standardized rate
 \item the population corresponding to the age or agecat in your original data
 }
 }
@@ -72,4 +83,7 @@ group_by = "sex")[]
 }
 \references{
 \url{https://github.com/PHSKC-APDE/rads/wiki/age_standardize}
+}
+\seealso{
+\code{\link{adjust_direct}} for calculating crude and directly adjusted rates.
 }

--- a/tests/testthat/test_utilities.R
+++ b/tests/testthat/test_utilities.R
@@ -47,6 +47,16 @@ test_that('age_standardize ... valid output',{
   temp.dt2 <- data.table(sex = c(rep("M", 11), rep("F", 11)), age = rep(50:60, 2),
                       count = c(25:35, 26:36), pop = c(seq(1000, 900, -10), seq(1100, 1000, -10)),
                       stdpop = rep(1000, 22))
+
+  expect_message(age_standardize(ph.data = temp.dt2, ref.popname = "none", collapse = F, my.count = "count",
+                                 my.pop = "pop", per = 1000, conf.level = 0.95, group_by = "sex", diagnostic_report = TRUE),
+                 'Returning diagnostic report instead of age-standardized rates')
+
+  diagreport <- suppressMessages(age_standardize(ph.data = temp.dt2, ref.popname = "none", collapse = F, my.count = "count",
+                                my.pop = "pop", per = 1000, conf.level = 0.95, group_by = "sex", diagnostic_report = TRUE))
+  expect_identical(unique(diagreport$missing), '0-49, 61-100')
+  expect_identical(sort(unique(diagreport$sex)), c('F', 'M'))
+
   temp.agestd2 <- suppressWarnings(age_standardize(ph.data = temp.dt2, ref.popname = "none", collapse = F, my.count = "count",
                   my.pop = "pop", per = 1000, conf.level = 0.95, group_by = "sex"))
 
@@ -126,7 +136,33 @@ test_that('age_standardize ... errors & warnings',{
                                  per = 100000,
                                  conf.level = 0.95,
                                  group_by = c('height', 'weight', 'gender')),
-                 'Group \\(Tall, Light, F\\) is missing ages: 20, 21, 22, 23, 24, 25')
+                 'Missing ages detected in tempy for 7 groups.')
+
+  # Warnings when only two groups
+  temp.dt2 <- data.table(sex = c(rep("M", 11), rep("F", 11)), age = rep(50:60, 2),
+                         count = c(25:35, 26:36), pop = c(seq(1000, 900, -10), seq(1100, 1000, -10)),
+                         stdpop = rep(1000, 22))
+
+  expect_warning(age_standardize(ph.data = temp.dt2,
+                                 ref.popname = "none",
+                                 collapse = F,
+                                 my.count = "count",
+                                 my.pop = "pop",
+                                 per = 1000,
+                                 conf.level = 0.95,
+                                 group_by = "sex"),
+                 'Missing ages detected in temp.dt2 for these groups:')
+
+  expect_warning(age_standardize(ph.data = temp.dt2,
+                                 ref.popname = "none",
+                                 collapse = F,
+                                 my.count = "count",
+                                 my.pop = "pop",
+                                 per = 1000,
+                                 conf.level = 0.95,
+                                 group_by = "sex"),
+                 'M 0-49, 61-100')
+
 
   # test if fails when have mismatched aggregated data
   set.seed(98104)

--- a/vignettes/age_standardize.Rmd
+++ b/vignettes/age_standardize.Rmd
@@ -69,6 +69,8 @@ Arguments are the values that we send to a function when it is called. The stand
 
 8)  `group_by` \<- a character vector, specifies the variable(s) by which to stratify the rate results (if any). The default is NULL (i.e., no stratification)
 
+9)  `diagnostic_report` \<- If `group_by` is used and there are groups with missing ages, setting `diagnostic_report = TRUE` returns a diagnostic table instead of normal results. Use this option if a warning about missing age groups appears when running the function normally.
+
 ## Preparing your dataset
 
 Your dataset must have the following three columns ...


### PR DESCRIPTION
- tweak so prints missing ages when use group_by and have 5 or fewer combinations with missing ages. Gives warning if >=6, and allows for output of problematic combination.
- updated header/helpful, vignette, and tests
- updated warning symbols to more visible warnings

```
── R CMD check results ────────────────────────────────────────────────── rads 1.3.3 ────
Duration: 21m 38.2s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔
```