### PR TITLE
check_version header now aligns with rads.data

### DIFF
--- a/R/check_version.R
+++ b/R/check_version.R
@@ -7,7 +7,7 @@
 #' @param print_message Logical. Whether to print messages about version status.
 #'   Default is TRUE.
 #'
-#' @return A list with the following components:
+#' @return Invisibly returns a list with the following components:
 #'   \item{is_current}{Logical. TRUE if the installed version is the latest, FALSE otherwise.}
 #'   \item{local_version}{The version of the installed rads package.}
 #'   \item{remote_version}{The version on GitHub, or NULL if it couldn't be determined.}
@@ -18,12 +18,6 @@
 #' \dontrun{
 #' # Check if rads is up to date
 #' check_version()
-#'
-#' # Check for updates silently
-#' status <- check_version(print_message = FALSE)
-#' if (!status$is_current) {
-#'   # Custom handling for outdated package
-#' }
 #' }
 #'
 #' @export

--- a/man/check_version.Rd
+++ b/man/check_version.Rd
@@ -11,7 +11,7 @@ check_version(print_message = TRUE)
 Default is TRUE.}
 }
 \value{
-A list with the following components:
+Invisibly returns a list with the following components:
 \item{is_current}{Logical. TRUE if the installed version is the latest, FALSE otherwise.}
 \item{local_version}{The version of the installed rads package.}
 \item{remote_version}{The version on GitHub, or NULL if it couldn't be determined.}
@@ -27,12 +27,6 @@ DESCRIPTION file on the main branch of the GitHub repository.
 \dontrun{
 # Check if rads is up to date
 check_version()
-
-# Check for updates silently
-status <- check_version(print_message = FALSE)
-if (!status$is_current) {
-  # Custom handling for outdated package
-}
 }
 
 }


### PR DESCRIPTION
 - rads.data functionally has the same function so aligned headers