### PR TITLE
Fix #475 ... tsql_validate_field_types annoyances

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rads
 Type: Package
 Title: Assisted computation of King County public health data
-Version: 1.5.5
+Version: 1.5.6
 Author: PHSKC-APDE
 Maintainer: Daniel Casey <Data.Request@kingcounty.gov>
 Description: Fetch and analyze data from Public Health Seattle & King County.
@@ -31,6 +31,7 @@ Remotes:
     github::PHSKC-APDE/rads.data, 
     github::PHSKC-APDE/dtsurvey
 Suggests: 
+    bit64, 
     devtools, 
     future, 
     future.apply,

--- a/R/globals.R
+++ b/R/globals.R
@@ -35,6 +35,7 @@ utils::globalVariables(c(
   "injury_nature_narrow",
   "intent",
   "intent_ignore",
+  "issue",
   "KeepMe",
   "lower_ci",
   "mean_est",

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -3310,17 +3310,11 @@ tsql_validate_field_types <- function(ph.data = NULL,
         message('\U0001f642 Success! Your desired TSQL data types are suitable for your dataset.')
       } else {
         invalid_columns <- validation_results[is_valid == FALSE]
-        stop(paste0(
-          '\n\U1F6D1\U0001f47f The following columns in your dataset did not ',
-          'align with the proposed TSQL field types:\n',
-          paste0(
-            "     column: ", invalid_columns$colname,
-            ", R Type: ", invalid_columns$R_type,
-            ", TSQL Type: ", invalid_columns$tsql_type,
-            ", issue: ", invalid_columns$issue,
-            collapse = "\n"
-          )
-        ))
+        cat("\n================ INVALID FIELD TYPES ================\n")
+        print(invalid_columns)
+        cat("======================================================\n")
+        stop(paste0('\n\U1F6D1\U0001f47f One or more columns did not align with the proposed TSQL field types.\n',
+                    'See the printed table above for full details.'))
       }
 
   # Return validation results ----

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -3164,7 +3164,8 @@ tsql_validate_field_types <- function(ph.data = NULL,
         logical = "bit",
         Date = "date",
         POSIXct = c("datetime", "datetime2", "smalldatetime", "datetimeoffset"),
-        raw = c("binary", "varbinary", "image")
+        raw = c("binary", "varbinary", "image"),
+        integer64 = "bigint"
       )
 
       type_constraints <- list(

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -3157,7 +3157,7 @@ tsql_validate_field_types <- function(ph.data = NULL,
 
   # Define type compatibility and constraints ----
       type_compatibility <- list(
-        integer = c("tinyint", "smallint", "int", "bigint", "bit"),
+        integer = c("tinyint", "smallint", "int", "bigint", "bit", "float", "real"),
         numeric = c("tinyint", "smallint", "int", "bigint", "decimal", "numeric", "float", "real", "money", "smallmoney"),
         character = c("char", "varchar", "text", "nchar", "nvarchar", "ntext"),
         factor = c("char", "varchar", "text", "nchar", "nvarchar", "ntext"),

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -3184,6 +3184,11 @@ tsql_validate_field_types <- function(ph.data = NULL,
 
     # Function to check type compatibility ----
         check_compatibility <- function(R_type, tsql_type) {
+          # Allow integer >> character types (varchar, char, nvarchar, nchar)
+          if (R_type == "integer" && tsql_type %in% c("char", "varchar", "nchar", "nvarchar")) {
+            return(TRUE)
+          }
+
           compatible_types <- unlist(type_compatibility[R_type])
           tsql_type %in% compatible_types
         }
@@ -3263,10 +3268,16 @@ tsql_validate_field_types <- function(ph.data = NULL,
         tsql_type = tsql_type,
         is_valid = is_compatible & meets_constraints,
         issue = fcase(
+          R_type == "integer" & tsql_type %in% c("char","varchar","nchar","nvarchar"),
+          "Warning: integer stored as character (allowed, but non-standard)",
+
           !is_compatible, "Incompatible types",
+
           !meets_constraints & R_type == "numeric" & tsql_type %in% c("tinyint", "smallint", "int", "bigint"),
           "Numeric values cannot be safely converted to integer",
+
           !meets_constraints, "Fails constraints",
+
           default = NA_character_
         )
       )]
@@ -3276,6 +3287,23 @@ tsql_validate_field_types <- function(ph.data = NULL,
       na_cols <- ph.data[, lapply(.SD, function(x) all(is.na(x))), .SDcols = names(ph.data)]
       na_cols <- names(na_cols)[as.logical(na_cols)]
       if(length(na_cols) > 0){warning('\u26A0\ufe0f Validation may be flawed for the following variables because they are 100% missing: ', paste0(na_cols, collapse = ', '))}
+
+      # Give warnings for nonstandard conversions
+      warning_rows <- validation_results[grepl("^Warning:", issue)]
+
+      if (nrow(warning_rows) > 0) {
+        warning(
+          "\nThe following columns have non-standard but allowed conversions:\n",
+          paste0(
+            "     column: ", warning_rows$colname,
+            ", R Type: ", warning_rows$R_type,
+            ", TSQL Type: ", warning_rows$tsql_type,
+            ", issue: ", warning_rows$issue,
+            collapse = "\n"
+          )
+        )
+      }
+
 
       # report back overall validation
       if (all(validation_results$is_valid)) {

--- a/tests/testthat/test_utilities.R
+++ b/tests/testthat/test_utilities.R
@@ -1,6 +1,7 @@
 library(testthat)
 library(DBI)
 library(data.table)
+library(bit64)
 
 # as_table_brfss() & as_imputed_brfss() ----
 test_that("confirm conversion to dtsurvey / data.table", {
@@ -1184,27 +1185,27 @@ test_that("function fails with incompatible field types", {
 
   bad_field_types <- data.table::copy(my_field_types)
   bad_field_types["col1"] <- "tinyint" # tinyint is too small (up to 255)
-  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'column: col1')
+  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'One or more columns did not align with the proposed TSQL field types')
 
   bad_field_types <- data.table::copy(my_field_types)
   bad_field_types["col2"] <- "nvarchar(20)" # does not expect moving dates to non dates in TSQL
-  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'column: col2')
+  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'One or more columns did not align with the proposed TSQL field types')
 
   bad_field_types <- data.table::copy(my_field_types)
   bad_field_types["col3"] <- "INT" # numeric cannot be changed to integer without loss
-  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'column: col3')
+  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'One or more columns did not align with the proposed TSQL field types')
 
   bad_field_types <- data.table::copy(my_field_types)
   bad_field_types["col4"] <- "nvarchar(25)" # not long enough for number of characters
-  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'column: col4')
+  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'One or more columns did not align with the proposed TSQL field types')
 
   bad_field_types <- data.table::copy(my_field_types)
   bad_field_types["col5"] <- "date" # R POSIXct should only map to some sort of datetime, not date
-  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'column: col5')
+  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'One or more columns did not align with the proposed TSQL field types')
 
   bad_field_types <- data.table::copy(my_field_types)
   bad_field_types["col6"] <- "bit" # bit is limited to logical or integers with only 0|1 values
-  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'column: col6')
+  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = bad_field_types), 'One or more columns did not align with the proposed TSQL field types')
 
 })
 
@@ -1241,7 +1242,7 @@ test_that("function handles unsupported R data types gracefully", {
 test_that("function correctly handles character fields at size limit", {
   mydt <- data.table(col1 = c("abc", "defgh", "ijklm"))
   expect_message(tsql_validate_field_types(ph.data = mydt, field_types = c(col1 = 'varchar(5)')), "Success")
-  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = c(col1 = 'varchar(4)')), "Fails constraints")
+  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = c(col1 = 'varchar(4)')), "One or more columns did not align with the proposed TSQL field types")
 })
 
 test_that("function correctly handles numeric to integer conversion", {
@@ -1250,7 +1251,7 @@ test_that("function correctly handles numeric to integer conversion", {
   expect_message(tsql_validate_field_types(ph.data = mydt, field_types = my_field_types), "Success")
 
   mydt <- data.table(col1 = c(1.1, 2.0, 3.0), col2 = c(4.0, 5.0, 6.0))
-  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = my_field_types), "Numeric values cannot be safely converted to integer")
+  expect_error(tsql_validate_field_types(ph.data = mydt, field_types = my_field_types), "One or more columns did not align with the proposed TSQL field types")
 })
 
 test_that("function correctly handles POSIXct types", {
@@ -1269,3 +1270,18 @@ test_that("function handles NA and NULL values correctly", {
   my_field_types <- c(col1 = 'int', col2 = 'varchar(10)', col3 = 'bit')
   expect_warning(tsql_validate_field_types(ph.data = mydt, field_types = my_field_types))
 })
+
+test_that("function supports integer64 and maps to bigint", {
+  mydt <- data.table(col1 = as.integer64(1:10))
+  my_field_types <- c(col1 = "bigint")
+  expect_message(tsql_validate_field_types(ph.data = mydt, field_types = my_field_types), "Success")
+})
+
+test_that("function allows integer to varchar but gives a warning", {
+  mydt <- data.table(col1 = 1:10)
+  my_field_types <- c(col1 = "varchar(10)")
+  expect_warning(tsql_validate_field_types(ph.data = mydt, field_types = my_field_types),
+                 "integer stored as character")
+})
+
+


### PR DESCRIPTION
Identified a few annoying things in `tsql_validate_field_types ` while using in BRFSS ETL so wanted to issue a quick fix before I forgot
- recognized R type integer64 and map to bigint in TSQL
- allow R type integer to be mapped to VARCHAR/CHAR/etc in TSQL, but give a warning. This is imported for things like SSN which are numbers, but which we want to store as strings
- allow integers in R to be mapped to FLOAT and REAL in TSQL ... Important when data COULD be a numeric/float, but, just be chance, in the given the upload it is integer
- provide the complete table of errors, rather than a truncated version within the stop 
- updated tests for the function
