### PR TITLE
FIX #478 PLUS better calc proporitions & metrics

### DIFF
--- a/R/calc.R
+++ b/R/calc.R
@@ -1,69 +1,76 @@
-#' Compute metrics from record (e.g. vital stats) or survey data
+#' Compute metrics from records (e.g. vital stats) or survey data
 #' @name calc
+#' @param ... Additional arguments passed to specific `calc` methods.
 #' @param ph.data data.table or tbl_svy. Dataset.
 #' @param what character vector. Variable to calculate metrics for. Must refer to a numeric or factor column.
 #' @param where subsetting expression
 #' @param by character vector. Must refer to variables within ph.data. The variables within ph.data to compute `what` by
-#' @param metrics character. See [metrics()] or scroll below for the available options.
-#' @param per integer. The denominator when "rate" or "adjusted-rate" are selected as the metric. Metrics will be multiplied by this value.
+#' @param metrics character. What calculation(s) do you need? See [metrics] for the available options.
+#' @param per integer. The denominator when "rate" is selected as the metric. Metrics will be multiplied by this value.
 #' @param win integer. The number of consecutive units of time (e.g., years, months, etc.) over which the metrics will be calculated,
 #' i.e., the 'window' for a rolling average, sum, etc.
-#' @param time_var character. The name of the time variable in the dataset. Used in combination with the "win" argument to do time windowed calculations.
+#' @param time_var character. The name of the time variable in the dataset. Used in combination with the "win" argument to perform time windowed calculations.
 #' @param fancy_time logical. If TRUE, a record of all the years going into the data is provided.
 #' If FALSE, just a simple range (where certain years within the range might not be represented in your data).
-#' @param proportion logical. For survey data, should metrics be calculated assuming the output is proportion-like? See details for more.
-#'                   Currently does not have functionality for non-survey data.
-#' @param ci numeric. Confidence level, >0 & <1, typically 0.95
+#' @param proportion character or logical. Should metrics be calculated assuming the output is
+#' proportion-like? See `Proportion-like and binary variables` below for more info. Must be one of
+#' `'autodetect'` (the default), `TRUE`, or `FALSE`:
+#'
+#'   - `'autodetect'`: for each `what` variable, rads determines whether it is structurally
+#'   proportion-like and/or binary, and applies proportion-appropriate confidence interval methods
+#'   and/or the binary RSE adjustment accordingly.
+#'
+#'   - `TRUE`: asserts that `what` is expected to be proportion-like (a factor, logical, or 0/1
+#'   numeric), which would drive the CI method for survey data. If it is not structurally
+#'   proportion-like, a warning is issued and standard (non-proportion) calculations are used
+#'   instead, equivalent to `proportion = 'autodetect'`.
+#'
+#'   - `FALSE`: force `what` to *not* be treated as proportion-like or binary, even if it is
+#'   structurally one or both of those things.
+#'
+#' @param ci numeric. Confidence level, `[0, 1]`, typically 0.95
 #' @param verbose logical. Mostly unused, but toggles on/off printed warnings.
-#' @param ... not implemented
 #' @references <https://github.com/PHSKC-APDE/rads/wiki/calc>
 #' @return a data.table containing the results
 #' @details
 #' This function calculates `metrics` for each variable in `what` from rows meeting the conditions specified
-#' by `where` for each grouping implied by `by`.
+#' by `where` for each grouping implied by `by`. See the [metrics] helpfile for details.
 #'
-#' Available metrics include:
+#' @section Proportion-like and binary variables:
+#' The `proportion` argument (`'autodetect'`, `TRUE`, or `FALSE`) controls how **`what`**
+#' variables that represent a proportion are handled. This covers two related but distinct
+#' ideas:
 #'
-#' 1) total: Count of people with the given value. Mostly relevant for surveys
-#' (where total is approximately mean * sum(pweights)).
-#' Returns total, total_se, total_upper, total_lower.
-#' total_se, total_upper, & total_lower are only valid for survey data.
-#' Default ci (e.g. upper and lower) is 95 percent.
+#' - **Proportion-like**: any factor (regardless of how many levels it has), a logical, or a numeric
+#' column containing only 0s and 1s. For these variables, every presented `mean` is itself a bounded
+#' `[0, 1]` proportion -- a factor level's share of the whole, or a 0/1 indicator's prevalence.
 #'
-#' 2) mean: Average response and associated metrics of uncertainty.
-#' Returns mean, mean_se, mean_lower, mean_upper.
-#' Default ci (e.g. upper and lower) is 95 percent.
+#' - **Binary**: the narrower case of a proportion-like variable that has *exactly* two possible outcomes.
 #'
-#' 3) rse: Relative standard error. 100*se/mean.
+#' These two ideas drive different pieces of the calculation:
 #'
-#' 4) numerator: Sum of non-NA values for `what``.
-#' The numerator is always unweighted.
+#' - **Confidence intervals (survey data only):** any *proportion-like* **`what`** gets a CI method
+#' appropriate for bounded `[0, 1]` quantities (e.g. `svyciprop`-style methods) instead of a
+#' standard mean-based CI that could extend outside that range. This only matters for survey
+#' data; administrative data always uses proportion-appropriate CIs for factors regardless of this
+#' argument.
 #'
-#' 5) denominator: Number of rows where `what` is not NA.
-#' The denominator is always unweighted.
+#' - **RSE (both survey and administrative data):** only *binary* **`what`** variables get the symmetric
+#' RSE adjustment, which changes the RSE denominator from the estimate itself to
+#' `min(estimate, 1 - estimate)`. See `rse` in [metrics] for more detail.
 #'
-#' 6) obs: Number of unique observations (i.e., rows), agnostic as to whether
-#' there is missing data for `what`. The obs is always unweighted.
+#' Under `'autodetect'` (the default), rads determines both properties empirically,
+#' separately for each **`what`** variable.
 #'
-#' 7) median: The median non NA response. Not populated when `what` is a factor
-#' or character. Even for surveys, the median is the unweighted result.
+#' `TRUE` asserts that **`what`** is *expected* to be proportion-like, and drives
+#' the CI method the same  way `'autodetect'` would if the expectation holds. If
+#' `what` turns out not to be structurally proportion-like, a warning is issued
+#' and calculations fall back to standard (non-proportion) treatment. It flags a
+#' mismatch between expectation and structure. As with `'autodetect'`, the RSE
+#' adjustment is only applied if the variable is *also* structurally binary.
 #'
-#' 8) unique.time: Number of unique time points (from `time_var`) included in
-#' each tabulation (i.e., number of unique time points when the `what` is not missing).
-#'
-#' 9) missing: Number of rows in a given grouping with an NA value for `what`.
-#'    missing + denominator = Number of people in a given group.
-#'    When `what` is a factor/character, the missing information is provided for the other.
-#'
-#' 10) missing.prop: The proportion of the data that has an NA value for `what`.
-#'
-#' 11) rate: mean * per. Provides rescaled mean estimates (i.e., per 100 or per 100,0000).
-#' Returns rate, rate_se, rate_lower, rate_upper.
-#' Default ci (e.g. upper and lower) is 95 percent.
-#'
-#'
-#' For survey data, use the `proportion` argument where relevant to ensure metrics are calculated using special proportion (e.g `svyciprop`)
-#' methods. That is, when you want to find the fraction of ____, toggle `proportion` to `TRUE`.
+#' `FALSE` forces standard (non-proportion, non-binary)
+#' treatment for both CIs and RSE, even if the variable is structurally proportion-like and/or binary.
 #'
 #' @export
 #'
@@ -138,7 +145,7 @@ calc.imputationList = function(ph.data,
                                per = NULL,
                                win = NULL,
                                time_var = NULL,
-                               proportion = FALSE,
+                               proportion = 'autodetect',
                                fancy_time = TRUE,
                                ci = .95,
                                verbose = FALSE,

--- a/R/calc.dtsurvey.R
+++ b/R/calc.dtsurvey.R
@@ -9,7 +9,7 @@ calc.dtsurvey <- function(ph.data,
                          per = NULL,
                          win = NULL,
                          time_var = NULL,
-                         proportion = FALSE,
+                         proportion = 'autodetect',
                          fancy_time = TRUE,
                          ci = .95,
                          verbose = FALSE,
@@ -24,6 +24,13 @@ calc.dtsurvey <- function(ph.data,
   }
 
   call = match.call() # get 'call' object containing function name plus every argument
+
+  # Preserve a reference to the pre-`where`-filter data. This is used later (after `what` has been
+  # validated) to autodetect whether each `what` variable is structurally binary. Purposefully
+  # detect using *unfiltered* data because a `where` clause could entirely eliminate some `what`
+  # values within a given call. This would make an otherwise-binary variable look non-binary (or vice
+  # versa). This is just a reference, not a copy, so not costly.
+  ph.data_prefilter = ph.data
 
   #filter the dataset
   if(!missing(where)){
@@ -92,6 +99,13 @@ calc.dtsurvey <- function(ph.data,
     stop('Must specify a `metric`')
   }
 
+  #validate 'proportion'
+  # Must be one of 'autodetect', TRUE, or FALSE. Anything else (including NA, other strings, etc.) is rejected.
+  if(!(is.character(proportion) && length(proportion) == 1 && identical(proportion, 'autodetect')) &&
+     !(is.logical(proportion) && length(proportion) == 1 && !is.na(proportion))){
+    stop("\n\U0001F92C The `proportion` argument must be one of: 'autodetect' (the default), TRUE, or FALSE.")
+  }
+
   #validate rate
   if("rate" %in% metrics & is.null(per)){
     per <- 1 # default denominator of 1
@@ -142,12 +156,35 @@ calc.dtsurvey <- function(ph.data,
 
   #if multiple whats are provided, compute per what
   res = lapply(what, function(wht){
+
+    #Determine, for this specific `what` variable, whether it is:
+    # -- proportion-like (important for CI calculation)
+    # -- binary (important for RSE calculation)
+    is_proportion_detected = is_proportion_var(ph.data_prefilter[[wht]])
+    is_binary_detected = is_binary_var(ph.data_prefilter[[wht]])
+
+    if(identical(proportion, 'autodetect')){
+      proportion_resolved = is_proportion_detected
+    }else if(isTRUE(proportion)){
+      proportion_resolved = is_proportion_detected
+      if(!is_proportion_detected){
+        warning(paste0(
+          '\n\u26A0\ufe0f `proportion` was set to TRUE for `', wht, '`, but this variable does not ',
+          'seem to be proportion-like (i.e., it is not a factor, a logical, or a numeric containing ',
+          'only 0s and 1s). `proportion` cannot be honored for this variable, so standard ',
+          '(non-proportion) calculations will be used instead (equivalent to `proportion = \'autodetect\'`).'
+        ))
+      }
+    }else{
+      proportion_resolved = FALSE
+    }
+
     #Determine the type of CI method to use
     meth = 'mean' #the default
     st = attr(ph.data, 'stype')
     whatfactor = is.factor(ph.data[[wht]])
-    if(st == 'admin' && (whatfactor || proportion == T)) meth = 'unweighted_binary'
-    if(st != 'admin' && proportion == T) meth = 'xlogit'
+    if(st == 'admin' && (whatfactor || proportion_resolved)) meth = 'unweighted_binary'
+    if(st != 'admin' && proportion_resolved) meth = 'xlogit'
 
     #Compute the metric
     r = lapply(wins, function(w){
@@ -156,10 +193,17 @@ calc.dtsurvey <- function(ph.data,
         sub_i = substitute(tv %in% w, list(tv = as.name(time_var), w = w))
       }
 
-      compute(eval(substitute(ph.data[sub_i], env = list(sub_i = sub_i))), wht, by = by, metrics,
-              ci_method = meth, level = ci,
-              time_var = time_var, time_format = time_format,
-              per = per, window = !(is.logical(sub_i) && sub_i))
+      compute(DT = eval(substitute(ph.data[sub_i], env = list(sub_i = sub_i))),
+              x = wht,
+              by = by,
+              metrics,
+              ci_method = meth,
+              level = ci,
+              time_var = time_var,
+              time_format = time_format,
+              per = per,
+              window = !(is.logical(sub_i) && sub_i),
+              binary = proportion_resolved && is_binary_detected)
     })
 
     data.table::rbindlist(r)
@@ -173,8 +217,47 @@ calc.dtsurvey <- function(ph.data,
 
 }
 
+#' Determine whether a variable is structurally binary.
+#' Used by `calc.dtsurvey()` to decide whether the RSE calculation should be:
+#' RSE = 100 * mean_se / mean
+#' OR
+#' RSE = 100 * mean_se / (min(mean, 1-mean))
+#' @param x a vector -- typically a column pulled from `ph.data` prior to any `where` filtering.
+#' @noRd
+#' @keywords internal
+is_binary_var <- function(x){
+  if(is.factor(x)){
+    return(nlevels(x) == 2)
+  }
+  if(is.logical(x)){
+    return(TRUE)
+  }
+  if(is.numeric(x)){
+    vals = unique(x[!is.na(x)])
+    if(length(vals) == 0) return(FALSE)
+    return(all(vals %in% c(0, 1)))
+  }
+  return(FALSE)
+}
+
+#' Determine whether a variable is proportion-like.
+#' Any factor qualifies here regardless of how many levels it has.
+#' Used by `calc.dtsurvey()` to resolve `proportion = 'autodetect'` and
+#' to decide whether proportion-appropriate CI methods should be applied for survey analyses.
+#' @param x a vector -- typically a column pulled from `ph.data` prior to any `where` filtering.
+#' @noRd
+#' @keywords internal
+is_proportion_var <- function(x){
+  if(is.factor(x)) return(TRUE)
+  is_binary_var(x) # if it is binary, treat it as a factor for CI calculations, even if not a true factor
+}
+
 #' A function to compute a metric as part of calc.dtsurvey
 #' see the help/documentation for calc and/or smeanto better understand the inputs
+#' @param binary logical. Whether `x` should be treated as a binary variable. When TRUE, `rse` is
+#' calculated as `100 * mean_se / min(mean, 1 - mean)` instead of `100 * mean_se / mean`.
+#' In essences, this will ascribe the maximal RSE from the estimate and it's complement. See
+#' [calc] documentation for details.
 #' @noRd
 #' @keywords internal
 compute <- function(DT,
@@ -186,7 +269,8 @@ compute <- function(DT,
                     time_var,
                     time_format,
                     per = 1,
-                    window = FALSE){
+                    window = FALSE,
+                    binary = FALSE){
 
 
   # if(nrow(DT) == 0) warning('No valid rows to compute on given `where` and `win` conditions')
@@ -203,31 +287,31 @@ compute <- function(DT,
   #construct the query
   if(any(c('mean', 'rate') %in% metrics)){
     mean_fun = substitute(list(dtsurvey::smean(x,
-                                                  na.rm = T,
-                                                  var_type = c('se', 'ci'),
-                                                  ci_method = cim,
-                                                  level = l,
-                                                  ids = `_id`,
-                                                  sv = ..sv,
-                                                  st = ..st)),
-                                       list(x = x,
-                                            l = level,
-                                            cim = I(ci_method)))
+                                               na.rm = T,
+                                               var_type = c('se', 'ci'),
+                                               ci_method = cim,
+                                               level = l,
+                                               ids = `_id`,
+                                               sv = ..sv,
+                                               st = ..st)),
+                          list(x = x,
+                               l = level,
+                               cim = I(ci_method)))
   }else{
     mean_fun = NULL
   }
 
   if('total' %in% metrics){
     total_fun = substitute(list(dtsurvey::stotal(x,
-                                                    na.rm = T,
-                                                    var_type = c('se', 'ci'),
-                                                    ci_method = 'total',
-                                                    level = l,
-                                                    ids = `_id`,
-                                                    sv = ..sv,
-                                                    st = ..st)),
-                                        list(x = x,
-                                             l = level))
+                                                 na.rm = T,
+                                                 var_type = c('se', 'ci'),
+                                                 ci_method = 'total',
+                                                 level = l,
+                                                 ids = `_id`,
+                                                 sv = ..sv,
+                                                 st = ..st)),
+                           list(x = x,
+                                l = level))
   }else{
     total_fun = NULL
   }
@@ -321,10 +405,10 @@ compute <- function(DT,
     mean_vcov_fun = NULL
     total_vcov_fun = NULL
   }
-  #use something like a = DT[, list(list(a), list(b)), env = list(a = mean_fun, b = total_fun), by = byvar]
-  #to capture the se and ci returns and then break out post hoc
-  #if it is a factor, compute some things separately
-  # Following bit creates the call taht will be executed within the data.table DT
+  # use something like a = DT[, list(list(a), list(b)), env = list(a = mean_fun, b = total_fun), by = byvar]
+  # to capture the se and ci returns and then break out post hoc
+  # if it is a factor, compute some things separately
+  # Following bit creates the call that will be executed within the data.table DT
   # This construction is used for flexibility (build the whole call and take out the null bits)
   the_call = substitute(list(
     time = time_fun,
@@ -474,7 +558,11 @@ compute <- function(DT,
 
   #if asked for, compute rse and rate
   if('rse' %in% metrics){
-    res[, rse := 100*(mean_se / mean)]
+    if(isTRUE(binary)){
+      res[, rse := 100 * (mean_se / pmin(mean, 1 - mean))] # need pmin because need minimum for each row
+    }else{
+      res[, rse := 100*(mean_se / mean)]
+    }
   }
 
   if('rate' %in% metrics){

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -668,60 +668,77 @@ lossless_convert <- function(x, class, column_name = NULL) {
 }
 
 # metrics() ----
-#' List of available metric for `calc`
+#' List of available metrics for `calc`
 #' @return character vector. A vector of the available metrics for `calc`
 #' @name metrics
 #' @details
-#' 1) total: Count of people with the given value. Mostly relevant for surveys
+#' 1) **mean**: Average response and associated metrics of uncertainty.
+#' Returns mean, mean_se, mean_lower, mean_upper.
+#' Default ci (e.g. upper and lower) is 95 percent.
+#'
+#' 2) **median**: The median non NA response. Not populated when `what` is a factor
+#' or character. Even for surveys, the median is the unweighted result.
+#'
+#' 3) **total**: Count of people with the given value. Mostly relevant for surveys
 #' (where total is approximately mean * sum(pweights)).
 #' Returns total, total_se, total_upper, total_lower.
 #' total_se, total_upper, & total_lower are only valid for survey data.
 #' Default ci (e.g. upper and lower) is 95 percent.
 #'
-#' 2) mean: Average response and associated metrics of uncertainty.
-#' Returns mean, mean_se, mean_lower, mean_upper.
-#' Default ci (e.g. upper and lower) is 95 percent.
+#' 4) **rse**: Relative standard error. Normally `100*se/mean`. However, for binary
+#' variables, rse is instead
+#' calculated as `100*se/min(mean, 1-mean)`. This is because the standard error
+#' of a binary proportion is identical to the standard error of its complement
+#' (e.g., `SE(p) == SE(1-p)`), but rse is not symmetric since it is a function
+#' of both the se and the estimate itself. Using the estimate that is <=50%
+#' ensures that an estimate and its complement are assigned the same (correct)
+#' rse, rather than one artificially appearing more/less reliable than the other.
+#' This adjustment applies only to binary (two-outcome) variables. See [calc]
+#' `Proportion-like and binary variables` for details.
 #'
-#' 3) rse: Relative standard error. 100*se/mean.
-#'
-#' 4) numerator: Sum of non-NA values for `what``.
-#' The numerator is always unweighted.
-#'
-#' 5) denominator: Number of rows where `what` is not NA.
-#' The denominator is always unweighted.
-#'
-#' 6) obs: Number of unique observations (i.e., rows), agnostic as to whether
-#' there is missing data for `what`. The obs is always unweighted.
-#'
-#' 7) median: The median non NA response. Not populated when `what` is a factor
-#' or character. Even for surveys, the median is the unweighted result.
-#'
-#' 8) unique.time: Number of unique time points (from `time_var`) included in
-#' each tabulation (i.e., number of unique time points when the `what` is not missing).
-#'
-#' 9) missing: Number of rows in a given grouping with an NA value for `what`.
-#'    missing + denominator = Number of people in a given group.
-#'    When `what` is a factor/character, the missing information is provided for the other.
-#'
-#' 10) missing.prop: The proportion of the data that has an NA value for `what`.
-#'
-#' 11) rate: mean * per. Provides rescaled mean estimates (i.e., per 100 or per 100,0000).
+#' 5) **rate**: mean * per. Provides rescaled mean estimates (i.e., per 100 or per 100,0000).
 #' Returns rate, rate_se, rate_lower, rate_upper.
 #' Default ci (e.g. upper and lower) is 95 percent.
 #'
-#' 12) ndistinct: The unique number of `what` values in the given subset. For factors, it is the unique number of levels in the subset.
+#' 6) **numerator**: Sum of non-NA values for `what``.
+#' The numerator is always unweighted.
+#'
+#' 7) **denominator**: Number of rows where `what` is not NA.
+#' The denominator is always unweighted.
+#'
+#' 8) **obs**: Number of unique observations (i.e., rows), agnostic as to whether
+#' there is missing data for `what`. The obs is always unweighted.
+#'
+#' 9) **missing**: Number of rows in a given grouping with an NA value for `what`.
+#'    missing + denominator = Number of people in a given group.
+#'    When `what` is a factor/character, the missing information is provided for the other.
+#'
+#' 10) **missing.prop**: The proportion of the data that has an NA value for `what`.
+#'
+#' 11) **unique.time**: Number of unique time points (from `time_var`) included in
+#' each tabulation (i.e., number of unique time points when the `what` is not missing).
+#'
+#' 12) **ndistinct**: The unique number of `what` values in the given subset. For
+#' factors, it is the unique number of levels in the subset.
+#'
+#' 13) **vcov**: Variance-covariance matrix for `mean` and/or `total`. Requires that
+#' `mean` and/or `total` also be included in `metrics`. Returns `mean_vcov` and/or
+#' `total_vcov` accordingly (list-columns containing the variance-covariance matrix).
+#' For non-factor `what`, this is a 1x1 matrix (i.e., just the variance of the estimate);
+#' for factor `what`, it is the full covariance matrix across levels. Mainly intended
+#' for internal us rather than direct interpretation.
 #'
 #' @rdname metrics
 #' @examples
 #' print(metrics())
 #' @export
 metrics = function(){
-  c('total',
-    'mean', 'rse',
-    'numerator','denominator', 'obs', 'median',
-    'unique.time',
+  c('mean', 'median', 'total',
+    'rse', 'rate',
+    'numerator','denominator', 'obs',
     'missing', 'missing.prop',
-    'rate', 'ndistinct', 'vcov')
+    'ndistinct', 'unique.time',
+    'vcov')
 }
 
 # multi_t_test ----

--- a/man/calc.Rd
+++ b/man/calc.Rd
@@ -3,7 +3,7 @@
 \name{calc}
 \alias{calc}
 \alias{calc.dtsurvey}
-\title{Compute metrics from record (e.g. vital stats) or survey data}
+\title{Compute metrics from records (e.g. vital stats) or survey data}
 \usage{
 calc(ph.data, ...)
 
@@ -16,7 +16,7 @@ calc(ph.data, ...)
   per = NULL,
   win = NULL,
   time_var = NULL,
-  proportion = FALSE,
+  proportion = "autodetect",
   fancy_time = TRUE,
   ci = 0.95,
   verbose = FALSE,
@@ -26,7 +26,7 @@ calc(ph.data, ...)
 \arguments{
 \item{ph.data}{data.table or tbl_svy. Dataset.}
 
-\item{...}{not implemented}
+\item{...}{Additional arguments passed to specific \code{calc} methods.}
 
 \item{what}{character vector. Variable to calculate metrics for. Must refer to a numeric or factor column.}
 
@@ -34,22 +34,34 @@ calc(ph.data, ...)
 
 \item{by}{character vector. Must refer to variables within ph.data. The variables within ph.data to compute \code{what} by}
 
-\item{metrics}{character. See \code{\link[=metrics]{metrics()}} or scroll below for the available options.}
+\item{metrics}{character. What calculation(s) do you need? See \link{metrics} for the available options.}
 
-\item{per}{integer. The denominator when "rate" or "adjusted-rate" are selected as the metric. Metrics will be multiplied by this value.}
+\item{per}{integer. The denominator when "rate" is selected as the metric. Metrics will be multiplied by this value.}
 
 \item{win}{integer. The number of consecutive units of time (e.g., years, months, etc.) over which the metrics will be calculated,
 i.e., the 'window' for a rolling average, sum, etc.}
 
-\item{time_var}{character. The name of the time variable in the dataset. Used in combination with the "win" argument to do time windowed calculations.}
+\item{time_var}{character. The name of the time variable in the dataset. Used in combination with the "win" argument to perform time windowed calculations.}
 
-\item{proportion}{logical. For survey data, should metrics be calculated assuming the output is proportion-like? See details for more.
-Currently does not have functionality for non-survey data.}
+\item{proportion}{character or logical. Should metrics be calculated assuming the output is
+proportion-like? See \verb{Proportion-like and binary variables} below for more info. Must be one of
+\code{'autodetect'} (the default), \code{TRUE}, or \code{FALSE}:
+\itemize{
+\item \code{'autodetect'}: for each \code{what} variable, rads determines whether it is structurally
+proportion-like and/or binary, and applies proportion-appropriate confidence interval methods
+and/or the binary RSE adjustment accordingly.
+\item \code{TRUE}: asserts that \code{what} is expected to be proportion-like (a factor, logical, or 0/1
+numeric), which would drive the CI method for survey data. If it is not structurally
+proportion-like, a warning is issued and standard (non-proportion) calculations are used
+instead, equivalent to \code{proportion = 'autodetect'}.
+\item \code{FALSE}: force \code{what} to \emph{not} be treated as proportion-like or binary, even if it is
+structurally one or both of those things.
+}}
 
 \item{fancy_time}{logical. If TRUE, a record of all the years going into the data is provided.
 If FALSE, just a simple range (where certain years within the range might not be represented in your data).}
 
-\item{ci}{numeric. Confidence level, >0 & <1, typically 0.95}
+\item{ci}{numeric. Confidence level, \verb{[0, 1]}, typically 0.95}
 
 \item{verbose}{logical. Mostly unused, but toggles on/off printed warnings.}
 }
@@ -57,45 +69,50 @@ If FALSE, just a simple range (where certain years within the range might not be
 a data.table containing the results
 }
 \description{
-Compute metrics from record (e.g. vital stats) or survey data
+Compute metrics from records (e.g. vital stats) or survey data
 }
 \details{
 This function calculates \code{metrics} for each variable in \code{what} from rows meeting the conditions specified
-by \code{where} for each grouping implied by \code{by}.
+by \code{where} for each grouping implied by \code{by}. See the \link{metrics} helpfile for details.
+}
+\section{Proportion-like and binary variables}{
 
-Available metrics include:
-\enumerate{
-\item total: Count of people with the given value. Mostly relevant for surveys
-(where total is approximately mean * sum(pweights)).
-Returns total, total_se, total_upper, total_lower.
-total_se, total_upper, & total_lower are only valid for survey data.
-Default ci (e.g. upper and lower) is 95 percent.
-\item mean: Average response and associated metrics of uncertainty.
-Returns mean, mean_se, mean_lower, mean_upper.
-Default ci (e.g. upper and lower) is 95 percent.
-\item rse: Relative standard error. 100*se/mean.
-\item numerator: Sum of non-NA values for `what``.
-The numerator is always unweighted.
-\item denominator: Number of rows where \code{what} is not NA.
-The denominator is always unweighted.
-\item obs: Number of unique observations (i.e., rows), agnostic as to whether
-there is missing data for \code{what}. The obs is always unweighted.
-\item median: The median non NA response. Not populated when \code{what} is a factor
-or character. Even for surveys, the median is the unweighted result.
-\item unique.time: Number of unique time points (from \code{time_var}) included in
-each tabulation (i.e., number of unique time points when the \code{what} is not missing).
-\item missing: Number of rows in a given grouping with an NA value for \code{what}.
-missing + denominator = Number of people in a given group.
-When \code{what} is a factor/character, the missing information is provided for the other.
-\item missing.prop: The proportion of the data that has an NA value for \code{what}.
-\item rate: mean * per. Provides rescaled mean estimates (i.e., per 100 or per 100,0000).
-Returns rate, rate_se, rate_lower, rate_upper.
-Default ci (e.g. upper and lower) is 95 percent.
+The \code{proportion} argument (\code{'autodetect'}, \code{TRUE}, or \code{FALSE}) controls how \strong{\code{what}}
+variables that represent a proportion are handled. This covers two related but distinct
+ideas:
+\itemize{
+\item \strong{Proportion-like}: any factor (regardless of how many levels it has), a logical, or a numeric
+column containing only 0s and 1s. For these variables, every presented \code{mean} is itself a bounded
+\verb{[0, 1]} proportion -- a factor level's share of the whole, or a 0/1 indicator's prevalence.
+\item \strong{Binary}: the narrower case of a proportion-like variable that has \emph{exactly} two possible outcomes.
 }
 
-For survey data, use the \code{proportion} argument where relevant to ensure metrics are calculated using special proportion (e.g \code{svyciprop})
-methods. That is, when you want to find the fraction of ____, toggle \code{proportion} to \code{TRUE}.
+These two ideas drive different pieces of the calculation:
+\itemize{
+\item \strong{Confidence intervals (survey data only):} any \emph{proportion-like} \strong{\code{what}} gets a CI method
+appropriate for bounded \verb{[0, 1]} quantities (e.g. \code{svyciprop}-style methods) instead of a
+standard mean-based CI that could extend outside that range. This only matters for survey
+data; administrative data always uses proportion-appropriate CIs for factors regardless of this
+argument.
+\item \strong{RSE (both survey and administrative data):} only \emph{binary} \strong{\code{what}} variables get the symmetric
+RSE adjustment, which changes the RSE denominator from the estimate itself to
+\code{min(estimate, 1 - estimate)}. See \code{rse} in \link{metrics} for more detail.
 }
+
+Under \code{'autodetect'} (the default), rads determines both properties empirically,
+separately for each \strong{\code{what}} variable.
+
+\code{TRUE} asserts that \strong{\code{what}} is \emph{expected} to be proportion-like, and drives
+the CI method the same  way \code{'autodetect'} would if the expectation holds. If
+\code{what} turns out not to be structurally proportion-like, a warning is issued
+and calculations fall back to standard (non-proportion) treatment. It flags a
+mismatch between expectation and structure. As with \code{'autodetect'}, the RSE
+adjustment is only applied if the variable is \emph{also} structurally binary.
+
+\code{FALSE} forces standard (non-proportion, non-binary)
+treatment for both CIs and RSE, even if the variable is structurally proportion-like and/or binary.
+}
+
 \examples{
 test.data <- rads.data::synthetic_birth
 

--- a/man/metrics.Rd
+++ b/man/metrics.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utilities.R
 \name{metrics}
 \alias{metrics}
-\title{List of available metric for \code{calc}}
+\title{List of available metrics for \code{calc}}
 \usage{
 metrics()
 }
@@ -10,37 +10,53 @@ metrics()
 character vector. A vector of the available metrics for \code{calc}
 }
 \description{
-List of available metric for \code{calc}
+List of available metrics for \code{calc}
 }
 \details{
 \enumerate{
-\item total: Count of people with the given value. Mostly relevant for surveys
+\item \strong{mean}: Average response and associated metrics of uncertainty.
+Returns mean, mean_se, mean_lower, mean_upper.
+Default ci (e.g. upper and lower) is 95 percent.
+\item \strong{median}: The median non NA response. Not populated when \code{what} is a factor
+or character. Even for surveys, the median is the unweighted result.
+\item \strong{total}: Count of people with the given value. Mostly relevant for surveys
 (where total is approximately mean * sum(pweights)).
 Returns total, total_se, total_upper, total_lower.
 total_se, total_upper, & total_lower are only valid for survey data.
 Default ci (e.g. upper and lower) is 95 percent.
-\item mean: Average response and associated metrics of uncertainty.
-Returns mean, mean_se, mean_lower, mean_upper.
-Default ci (e.g. upper and lower) is 95 percent.
-\item rse: Relative standard error. 100*se/mean.
-\item numerator: Sum of non-NA values for `what``.
-The numerator is always unweighted.
-\item denominator: Number of rows where \code{what} is not NA.
-The denominator is always unweighted.
-\item obs: Number of unique observations (i.e., rows), agnostic as to whether
-there is missing data for \code{what}. The obs is always unweighted.
-\item median: The median non NA response. Not populated when \code{what} is a factor
-or character. Even for surveys, the median is the unweighted result.
-\item unique.time: Number of unique time points (from \code{time_var}) included in
-each tabulation (i.e., number of unique time points when the \code{what} is not missing).
-\item missing: Number of rows in a given grouping with an NA value for \code{what}.
-missing + denominator = Number of people in a given group.
-When \code{what} is a factor/character, the missing information is provided for the other.
-\item missing.prop: The proportion of the data that has an NA value for \code{what}.
-\item rate: mean * per. Provides rescaled mean estimates (i.e., per 100 or per 100,0000).
+\item \strong{rse}: Relative standard error. Normally \code{100*se/mean}. However, for binary
+variables, rse is instead
+calculated as \code{100*se/min(mean, 1-mean)}. This is because the standard error
+of a binary proportion is identical to the standard error of its complement
+(e.g., \code{SE(p) == SE(1-p)}), but rse is not symmetric since it is a function
+of both the se and the estimate itself. Using the estimate that is <=50\%
+ensures that an estimate and its complement are assigned the same (correct)
+rse, rather than one artificially appearing more/less reliable than the other.
+This adjustment applies only to binary (two-outcome) variables. See \link{calc}
+\verb{Proportion-like and binary variables} for details.
+\item \strong{rate}: mean * per. Provides rescaled mean estimates (i.e., per 100 or per 100,0000).
 Returns rate, rate_se, rate_lower, rate_upper.
 Default ci (e.g. upper and lower) is 95 percent.
-\item ndistinct: The unique number of \code{what} values in the given subset. For factors, it is the unique number of levels in the subset.
+\item \strong{numerator}: Sum of non-NA values for `what``.
+The numerator is always unweighted.
+\item \strong{denominator}: Number of rows where \code{what} is not NA.
+The denominator is always unweighted.
+\item \strong{obs}: Number of unique observations (i.e., rows), agnostic as to whether
+there is missing data for \code{what}. The obs is always unweighted.
+\item \strong{missing}: Number of rows in a given grouping with an NA value for \code{what}.
+missing + denominator = Number of people in a given group.
+When \code{what} is a factor/character, the missing information is provided for the other.
+\item \strong{missing.prop}: The proportion of the data that has an NA value for \code{what}.
+\item \strong{unique.time}: Number of unique time points (from \code{time_var}) included in
+each tabulation (i.e., number of unique time points when the \code{what} is not missing).
+\item \strong{ndistinct}: The unique number of \code{what} values in the given subset. For
+factors, it is the unique number of levels in the subset.
+\item \strong{vcov}: Variance-covariance matrix for \code{mean} and/or \code{total}. Requires that
+\code{mean} and/or \code{total} also be included in \code{metrics}. Returns \code{mean_vcov} and/or
+\code{total_vcov} accordingly (list-columns containing the variance-covariance matrix).
+For non-factor \code{what}, this is a 1x1 matrix (i.e., just the variance of the estimate);
+for factor \code{what}, it is the full covariance matrix across levels. Mainly intended
+for internal us rather than direct interpretation.
 }
 }
 \examples{

--- a/tests/testthat/test-calc-proportions.R
+++ b/tests/testthat/test-calc-proportions.R
@@ -1,0 +1,279 @@
+library(data.table)
+library(dtsurvey)
+
+# test internal functions ----
+test_that("is_binary_var() correctly classifies data", {
+  # factors
+  expect_true(is_binary_var(factor(c("Yes", "No", "Yes"), levels = c("Yes", "No"))))
+  expect_false(is_binary_var(factor(c("A", "B", "C"), levels = c("A", "B", "C"))))
+  expect_false(is_binary_var(factor(c("A"), levels = c("A"))))
+
+  # logicals
+  expect_true(is_binary_var(c(TRUE, FALSE, TRUE, NA)))
+  expect_true(is_binary_var(c(TRUE, TRUE, TRUE)))
+
+  # numeric
+  expect_true(is_binary_var(c(0, 1, 0, 1, NA)))
+  expect_true(is_binary_var(c(0L, 1L, 1L)))
+  expect_false(is_binary_var(c(0, 1, 2)))
+  expect_false(is_binary_var(c(0.5, 1, 0)))
+  expect_false(is_binary_var(rep(NA_real_, 5)))
+  expect_true(is_binary_var(c(1, 1, 1)))
+
+  # character
+  expect_false(is_binary_var(c("0", "1", "0")))
+})
+
+test_that("is_proportion_var() correctly classifies data", {
+  # factors
+  expect_true(is_proportion_var(factor(c("Yes", "No", "Yes"), levels = c("Yes", "No"))))
+  expect_true(is_proportion_var(factor(c("A", "B", "C"), levels = c("A", "B", "C"))))
+  expect_true(is_proportion_var(factor(c("A"), levels = c("A"))))
+
+  # logicals
+  expect_true(is_proportion_var(c(TRUE, FALSE, TRUE, NA)))
+
+  # numerics
+  expect_true(is_proportion_var(c(0, 1, 0, 1, NA))) # because binary
+  expect_false(is_proportion_var(c(0, 1, 2)))
+  expect_false(is_proportion_var(c(0.5, 1, 0)))
+  expect_false(is_proportion_var(rep(NA_real_, 5)))
+
+  # character
+  expect_false(is_proportion_var(c("0", "1", "0")))
+})
+
+
+# calc() on admin data: binary numeric (0/1) ----
+make_admin_data <- function(n = 2000, p = 0.08, seed = 1){
+  set.seed(seed)
+  dt <- data.table::data.table(
+    id = seq_len(n),
+    diabetes = rbinom(n, 1, p),          # 0/1 numeric indicator, prevalence ~p
+    grp = sample(c("A", "B"), n, replace = TRUE)
+  )
+  dt[, not_diabetes := 1L - diabetes]     # explicit complement, for symmetry checks
+  dtsurvey::dtadmin(dt)
+}
+
+test_that("autodetect applies the flipped RSE formula to a 0/1 numeric indicator", {
+  ph <- make_admin_data()
+
+  res_default  <- calc(ph, what = "diabetes", metrics = c("mean", "rse"))
+  res_explicit <- calc(ph, what = "diabetes", metrics = c("mean", "rse"), proportion = TRUE)
+
+  expect_equal(res_default$rse, res_explicit$rse)
+
+  # Manually verify the formula: 100 * se / min(mean, 1-mean)
+  expected_rse <- 100 * res_default$mean_se / pmin(res_default$mean, 1 - res_default$mean)
+  expect_equal(res_default$rse, expected_rse)
+})
+
+test_that("a 0/1 indicator and its explicit complement get identical RSE under autodetect", {
+  ph <- make_admin_data()
+
+  res_x    <- calc(ph, what = "diabetes",     metrics = c("mean", "rse"))
+  res_notx <- calc(ph, what = "not_diabetes", metrics = c("mean", "rse"))
+
+  # Estimates should be complementary...
+  expect_equal(res_x$mean, 1 - res_notx$mean, tolerance = 1e-8)
+
+  # RSE should be identical
+  expect_equal(res_x$rse, res_notx$rse, tolerance = 1e-8)
+})
+
+test_that("proportion = FALSE forces the standard (asymmetric) RSE formula", {
+  ph <- make_admin_data()
+
+  res_false <- calc(ph, what = "not_diabetes", metrics = c("mean", "rse"), proportion = FALSE)
+  expected_rse <- 100 * res_false$mean_se / res_false$mean
+  expect_equal(res_false$rse, expected_rse)
+
+  # Should differ from RSE when proportion autodetected
+  res_auto <- calc(ph, what = "not_diabetes", metrics = c("mean", "rse"), proportion = 'autodetect')
+  expect_false(isTRUE(all.equal(res_false$rse, res_auto$rse)))
+})
+
+# calc() on admin data: 2-level factor ----
+make_admin_factor_data <- function(n = 2000, p = 0.08, seed = 2){
+  set.seed(seed)
+  dt <- data.table::data.table(
+    id = seq_len(n),
+    burden = factor(rbinom(n, 1, p), levels = c(0, 1), labels = c("Not burdened", "Burdened"))
+  )
+  dtsurvey::dtadmin(dt)
+}
+
+test_that("both levels of a 2-level factor receive the same RSE under autodetect", {
+  ph <- make_admin_factor_data()
+  res <- calc(ph, what = "burden", metrics = c("mean", "rse"))
+
+  # Both rows should carry the identical rse value
+  expect_equal(res$rse[1], res$rse[2])
+
+  # Manually test that RSE = 100 * se / min(mean, 1-mean) using EITHER row
+  expected_rse1 <- 100 * res$mean_se[1] / min(res$mean[1], 1 - res$mean[1])
+  expect_equal(res$rse[2], expected_rse1)
+
+  expected_rse2 <- 100 * res$mean_se[2] / min(res$mean[2], 1 - res$mean[2])
+  expect_equal(res$rse[1], expected_rse2)
+})
+
+# calc() on admin data: 3+ level factor (RSE should be unaffected) ----
+make_admin_multilevel_data <- function(n = 2000, seed = 3){
+  set.seed(seed)
+  dt <- data.table::data.table(
+    id = seq_len(n),
+    cat3 = factor(sample(c("Low", "Medium", "High"), n, replace = TRUE, prob = c(0.7, 0.2, 0.1)),
+                  levels = c("Low", "Medium", "High"))
+  )
+  dtsurvey::dtadmin(dt)
+}
+
+test_that("3-level factors keep the original (per-level) RSE formula, not the binary flip", {
+  ph <- make_admin_multilevel_data()
+  res <- calc(ph, what = "cat3", metrics = c("mean", "rse"))
+
+  expected_rse <- 100 * res$mean_se / res$mean
+  expect_equal(res$rse, expected_rse)
+
+  # Sanity check: rse should NOT all be identical here (unlike binary cases)
+  expect_gt(length(unique(res$rse)), 1)
+})
+
+# proportion argument validation ----
+test_that("invalid `proportion` values trigger an error", {
+  ph <- make_admin_data()
+  expect_error(calc(ph, what = "diabetes", metrics = "mean", proportion = "yes"))
+  expect_error(calc(ph, what = "diabetes", metrics = "mean", proportion = NA))
+  expect_error(calc(ph, what = "diabetes", metrics = "mean", proportion = c(TRUE, FALSE)))
+})
+
+test_that("proportion = TRUE on a variable that isn't proportion-like warns but still runs", {
+  # A continuous numeric (not a factor, not logical, not 0/1) is the only case that should warn --
+  # a 3+ level factor is proportion-like (see tests below) and should NOT warn.
+  set.seed(98104)
+  dt <- data.table::data.table(weight_kg = rnorm(500, 70, 10))
+  ph <- dtsurvey::dtadmin(dt)
+
+  expect_warning(
+    calc(ph, what = "weight_kg", metrics = c("mean", "rse"), proportion = TRUE),
+    "does not seem to be proportion-like"
+  )
+})
+
+test_that("proportion = TRUE on a genuinely binary variable does NOT warn", {
+  ph <- make_admin_data()
+  expect_no_warning(calc(ph, what = "diabetes", metrics = c("mean", "rse"), proportion = TRUE))
+})
+
+test_that("proportion = TRUE on a 3-level factor does NOT warn (it's proportion-like, just not binary)", {
+  ph <- make_admin_multilevel_data()
+  expect_no_warning(calc(ph, what = "cat3", metrics = c("mean", "rse"), proportion = TRUE))
+})
+
+# logical variables ----
+test_that("logical `what` variables are autodetected as binary and get the flipped RSE", {
+  set.seed(98104)
+  dt <- data.table::data.table(flag = sample(c(TRUE, FALSE), 2000, replace = TRUE, prob = c(0.1, 0.9)))
+  ph <- dtsurvey::dtadmin(dt)
+
+  res <- calc(ph, what = "flag", metrics = c("mean", "rse"))
+  expected_rse <- 100 * res$mean_se / min(res$mean, 1 - res$mean)
+  expect_equal(res$rse, expected_rse)
+})
+
+# detection happens pre-`where`-filter ----
+# a real 0|1 variable is *always* still 0|1 in any row-subset, so filtering it down
+# to an all-1s (or all-0s) subset should not change its identification as a binary.
+# More importantly, consider the case where a variable that is NOT structurally
+# binary (e.g. it has values 0, 1, *and* 2) but where a `where` clause coincidentally
+# leaves only 0s|1s behind. This is why we want to use the pre-filtered column.
+
+test_that("binary detection is based on the full column, not the `where`-filtered subset", {
+  set.seed(98104)
+  n <- 500
+  dt <- data.table::data.table(
+    id = seq_len(n),
+    # genuinely 3-valued (0/1/2) in the full data -- not structurally binary
+    score = c(rep(0L, 285), rep(1L, 15), rep(2L, 200)),
+    grp = c(rep("low_only", 300), rep("mixed", 200))
+  )
+  ph <- dtsurvey::dtadmin(dt)
+
+  # within "low_only", `score` only takes values 0 and 1 -- i.e., a false binary
+  res <- calc(ph, what = "score", where = grp == "low_only", metrics = c("mean", "rse"))
+
+  expect_equal(nrow(res), 1)
+
+  # standard (non-flipped) rse formula should apply, since the full `score` column is not binary
+  expect_equal(res$rse, 100 * res$mean_se / (res$mean))
+})
+
+# survey data: RSE should be same for both levels of a binary ----
+test_that("SE(p) == SE(1-p) holds for weighted survey estimates too (2-level factor)", {
+  set.seed(98104)
+  n <- 1000
+  dt <- data.table::data.table(
+    id = seq_len(n),
+    psu = seq_len(n),
+    strata = sample(1:5, n, replace = TRUE),
+    wt = runif(n, 0.5, 2),
+    burden = factor(rbinom(n, 1, 0.08), levels = c(0, 1), labels = c("Not burdened", "Burdened"))
+  )
+
+  svy <- dtsurvey::dtsurvey(dt, weight = "wt", psu = "psu", strata = "strata")
+
+  res <- calc(svy, what = "burden", metrics = c("mean", "rse"))
+  expect_equal(nrow(res), 2)
+  expect_equal(res$mean_se[1], res$mean_se[2])
+  expect_equal(res$rse[1], res$rse[2])
+})
+
+# proportion` now also drives CI method selection, not just rse ----
+test_that("autodetect uses the xlogit CI (like proportion = TRUE), not the plain mean CI, for a binary factor on survey data", {
+  set.seed(98104)
+  n <- 1000
+  dt <- data.table::data.table(
+    id = seq_len(n),
+    psu = seq_len(n),
+    strata = sample(1:5, n, replace = TRUE),
+    wt = runif(n, 0.5, 2),
+    burden = factor(rbinom(n, 1, 0.08), levels = c(0, 1), labels = c("Not burdened", "Burdened"))
+  )
+  svy <- dtsurvey::dtsurvey(dt, weight = "wt", psu = "psu", strata = "strata")
+
+  res_auto  <- calc(svy, what = "burden", metrics = c("mean"), proportion = 'autodetect')
+  res_true  <- calc(svy, what = "burden", metrics = c("mean"), proportion = TRUE)
+  res_false <- calc(svy, what = "burden", metrics = c("mean"), proportion = FALSE)
+
+  # autodetect should match the explicit xlogit (proportion = TRUE) CI, not the plain-mean one
+  expect_equal(res_auto$mean_lower, res_true$mean_lower)
+  expect_equal(res_auto$mean_upper, res_true$mean_upper)
+  expect_false(isTRUE(all.equal(res_auto$mean_lower, res_false$mean_lower)))
+  expect_false(isTRUE(all.equal(res_auto, res_false)))
+})
+
+test_that("autodetect gives a 3-level survey factor proportion-appropriate CIs too, even though it isn't binary", {
+  set.seed(98104)
+  n <- 1000
+  dt <- data.table::data.table(
+    id = seq_len(n),
+    psu = seq_len(n),
+    strata = sample(1:5, n, replace = TRUE),
+    wt = runif(n, 0.5, 2),
+    cat3 = factor(sample(c("Low", "Medium", "High"), n, replace = TRUE, prob = c(0.7, 0.2, 0.08)),
+                  levels = c("Low", "Medium", "High"))
+  )
+  svy <- dtsurvey::dtsurvey(dt, weight = "wt", psu = "psu", strata = "strata")
+
+  res_auto  <- calc(svy, what = "cat3", metrics = c("mean", "rse"), proportion = 'autodetect')
+  res_true  <- calc(svy, what = "cat3", metrics = c("mean", "rse"), proportion = TRUE)
+  res_false <- calc(svy, what = "cat3", metrics = c("mean", "rse"), proportion = FALSE)
+
+  # autodetect's CIs should match the explicit proportion = TRUE (xlogit) CIs...
+  expect_equal(res_auto$mean_lower, res_true$mean_lower)
+  expect_equal(res_auto$mean_upper, res_true$mean_upper)
+  # ...and differ from the plain mean-based CI (proportion = FALSE)
+  expect_false(isTRUE(all.equal(res_auto$mean_lower, res_false$mean_lower)))
+})


### PR DESCRIPTION
- For binary data, change RSE from `RSE = SE / EST` to `RSE = SE / pmin(EST, 1-EST)`. As per analysis guide and discussion in epi coordination meeting
- set `proportion = 'autodetect'` as default in `calc()`
- regrouped metrics and added @param for vcov
- many tests for binary RSE and detection of proportions for CI calculations
- passes all tests