### PR TITLE
Close #481

### DIFF
--- a/R/chars_functions.R
+++ b/R/chars_functions.R
@@ -329,13 +329,19 @@ chars_injury_matrix_count <- function(ph.data = NULL,
         by = by
       ]
 
-      # create grid of all possible combinations of by vars
-      gridvars <- setdiff(names(temp.ph.data), 'hospitalizations')
-      complete.grid <- do.call(data.table::CJ, lapply(gridvars, function(x) unique(temp.ph.data[[x]])))
-      data.table::setnames(complete.grid, gridvars)
+      # create grid of all possible combinations of by vars ----
+      if (!is.null(by)) {
+        complete.grid <- do.call(data.table::CJ, lapply(by, function(x) unique(ph.data[[x]])))
+        data.table::setnames(complete.grid, by)
+        complete.grid[, c("mechanism", "intent") := list(current_mechanism, current_intent)]
+      } else {
+        complete.grid <- data.table::data.table(mechanism = current_mechanism, intent = current_intent)
+      }
 
       # merge temp.ph.data onto complete.grid
-      temp.ph.data <- merge(complete.grid, temp.ph.data, all = TRUE)
+      temp.ph.data <- merge(complete.grid, temp.ph.data,
+                            by = c("mechanism", "intent", by),
+                            all = TRUE)
       temp.ph.data[is.na(hospitalizations), hospitalizations := 0L]
 
       return(temp.ph.data)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,21 @@
+library(data.table)
+
+# Confirm that every combination of `group_cols` is present in `dt`, and that
+# `count_col` is never NA (i.e., missing combinations were zero-filled rather
+# than dropped). Returns the zero-filled data.table invisibly for further
+# inspection by individual tests.
+expect_complete_table <- function(dt, group_cols, count_col) {
+  full_grid <- do.call(data.table::CJ, c(lapply(group_cols, function(col) unique(dt[[col]])),
+                                         list(sorted = FALSE)))
+  data.table::setnames(full_grid, group_cols)
+
+  data.table::setkeyv(full_grid, group_cols)
+  dt_key <- data.table::copy(dt)
+  data.table::setkeyv(dt_key, group_cols)
+
+  testthat::expect_equal(nrow(dt), nrow(full_grid))
+  testthat::expect_equal(nrow(full_grid[!dt_key]), 0L)
+  testthat::expect_false(anyNA(dt[[count_col]]))
+
+  invisible(dt)
+}

--- a/tests/testthat/test-chars_functions.R
+++ b/tests/testthat/test-chars_functions.R
@@ -148,6 +148,25 @@ library(data.table)
     expect_warning(chars_icd_ccs_count(ph.data = charsdata, icdcm = '^Kidney transplant', icdcol = 'chi_sex'))
     })
 
+  test_that("chars_icd_ccs_count() zero-fills a `by` group with no hospitalizations for the specified diagnosis", {
+    set.seed(98104)
+    d <- data.table::copy(rads.data::synthetic_chars)
+    d[, race := sample(c("White", "Black", "Asian", "Hispanic", "AIAN", "NHPI"), .N, replace = TRUE)]
+
+    ref <- chars_icd_ccs(icdcm_version = 10)
+    bc <- "Certain conditions originating in the perinatal period"
+    codes_in_broad <- unique(ref[broad == bc]$icdcm_code)
+    d[race == "NHPI" & diag1 %in% codes_in_broad, diag1 := "Z00"]
+
+    res <- chars_icd_ccs_count(ph.data = d,
+                               icdcm_version = 10,
+                               broad = bc,
+                               icdcol = "diag1",
+                               by = "race")
+
+    expect_complete_table(res, "race", "hospitalizations") # in helpers.R
+    expect_identical(res[race == "NHPI"]$hospitalizations, 0L)
+  })
 
 # Check chars_injury_matrix() ----
   injurytable <- chars_injury_matrix()
@@ -249,4 +268,51 @@ library(data.table)
     # should error when primary_ecode == F
     expect_error(chars_injury_matrix_count(ph.data = charsdt, mechanism = '*', intent = '*', def = 'narrow', primary_ecode = F))
 
+  })
+
+  test_that("chars_injury_matrix_count() zero-fills a `by` group with no hospitalizations for a mechanism x intent", {
+    d <- data.table::copy(charsdt)
+
+    # remove all fall/unintentional hospitalizations for NHPI (reassign to a different mechanism)
+    d[race4 == "NHPI" & injury_mechanism == "fall" & injury_intent == "unintentional",
+      injury_mechanism := "drowning"]
+
+    res <- chars_injury_matrix_count(ph.data = d,
+                                     intent = "*",
+                                     mechanism = "*",
+                                     by = "race4",
+                                     def = "narrow")
+
+    expect_complete_table(res, c("race4", "mechanism", "intent"), "hospitalizations") # in helpers
+    expect_identical(res[race4 == "NHPI" & mechanism == "fall" & intent == "unintentional"]$hospitalizations, 0L)
+  })
+
+  test_that("chars_injury_matrix_count() zero-fills every combination of MULTIPLE `by` variables", {
+    d <- data.table::copy(charsdt)
+    d[, agegrp := sample(c("under65", "65+"), .N, replace = TRUE)]
+
+    d[race4 == "NHPI" & agegrp == "65+" & injury_mechanism == "fall" & injury_intent == "unintentional",
+      injury_mechanism := "drowning"]
+
+    res <- chars_injury_matrix_count(ph.data = d,
+                                     intent = "*",
+                                     mechanism = "*",
+                                     by = c("race4", "agegrp"),
+                                     def = "narrow")
+
+    expect_complete_table(res, c("race4", "agegrp", "mechanism", "intent"), "hospitalizations") # in helpers.R
+    expect_identical(res[race4 == "NHPI" & agegrp == "65+" &
+                           mechanism == "fall" & intent == "unintentional"]$hospitalizations, 0L)
+    expect_gt(res[race4 == "NHPI" & agegrp == "under65" &
+                    mechanism == "fall" & intent == "unintentional"]$hospitalizations, 0L)
+  })
+
+  test_that("chars_injury_matrix_count() zero-fill still works with by = NULL and 'none' collapsing", {
+    res <- chars_injury_matrix_count(ph.data = data.table::copy(charsdt),
+                                     intent = "none",
+                                     mechanism = "none",
+                                     by = NULL,
+                                     def = "narrow")
+    expect_equal(nrow(res), 1L)
+    expect_false(anyNA(res$hospitalizations))
   })

--- a/tests/testthat/test-death_functions.R
+++ b/tests/testthat/test-death_functions.R
@@ -22,6 +22,9 @@ library(data.table)
   # death_113_count() create data ----
     deathDT <- rads.data::synthetic_death
 
+    deathDT2 <- data.table::copy(rads.data::synthetic_death)
+    deathDT2[, age_grp := data.table::fifelse(age >= 65, "65+", "under65")]
+
   # death_113_count() create output ----
     cod.of.interest <- c("Arthropod-borne viral encephalitis",
                          "Malaria",
@@ -106,6 +109,60 @@ library(data.table)
                  c('cause.of.death', 'causeid', 'deaths', 'temperament'))
     expect_equal(sort(unique(suppressWarnings(death_113_count(ph.data = deathDT, icdcol = 'underlying_cod_code', by = c('temperament')))[]$temperament)),
                  c('Active', 'Calm', 'Moderate')) # ensure all strata are present
+  })
+
+  test_that("death_113_count() zero-fills a single `by` group with no deaths for a given cause", {
+    d <- data.table::copy(deathDT2)
+
+    # remove all "Certain other intestinal infections" (causeid == 3) deaths for NHPI
+    codes3 <- unique(rads.data::icd_nchs113causes[causeid == 3]$icd10)
+    d[race == "NHPI" & underlying_cod_code %in% codes3, underlying_cod_code := "I219"] # myocardial infarction
+
+    res <- suppressWarnings(death_113_count(ph.data = d,
+                                            causeids = 1:20,
+                                            icdcol = "underlying_cod_code",
+                                            by = "race"))
+
+    expect_complete_table(res, c("race", "cause.of.death"), "deaths") # in helpers.R
+    expect_identical(res[race == "NHPI" & causeid == "3"]$deaths, 0L)
+  })
+
+  test_that("death_113_count() zero-fills every combination of MULTIPLE `by` variables", {
+    d <- data.table::copy(deathDT2)
+
+    # remove all "Human immunodeficiency virus (HIV) disease" (causeid == 15) deaths
+    # for Hispanic decedents 65+, but leave Hispanic under65 untouched
+    codes15 <- unique(rads.data::icd_nchs113causes[causeid == 15]$icd10)
+    d[race == "Hispanic" & age_grp == "65+" & underlying_cod_code %in% codes15,
+      underlying_cod_code := "I219"]  # myocardial infarction
+
+    res <- suppressWarnings(death_113_count(ph.data = d,
+                                            causeids = 1:20,
+                                            icdcol = "underlying_cod_code",
+                                            by = c("race", "age_grp")))
+
+    expect_complete_table(res, c("race", "age_grp", "cause.of.death"), "deaths") # in helpers.R
+    expect_identical(res[race == "Hispanic" & age_grp == "65+" & causeid == "15"]$deaths, 0L)
+    # the untouched group should still show its (nonzero) count
+    expect_gt(res[race == "Hispanic" & age_grp == "under65" & causeid == "15"]$deaths, 0L)
+  })
+
+  test_that("death_113_count() zero-fill still works with ypll_age specified", {
+    d <- data.table::copy(deathDT2)
+    codes3 <- unique(rads.data::icd_nchs113causes[causeid == 3]$icd10)
+    d[race == "NHPI" & underlying_cod_code %in% codes3, underlying_cod_code := "I219"]  # myocardial infarction
+
+    res <- suppressWarnings(death_113_count(ph.data = d,
+                                            causeids = 1:20,
+                                            icdcol = "underlying_cod_code",
+                                            by = "race",
+                                            ypll_age = 65,
+                                            death_age_col = "age"))
+
+    expect_complete_table(res, c("race", "cause.of.death"), "deaths") # in helpers.R
+    expect_false(anyNA(res$ypll_65))
+    expect_identical(res[race == "NHPI" & causeid == "3"]$deaths, 0L)
+    expect_identical(res[race == "NHPI" & causeid == "3"]$ypll_65, 0)
   })
 
 # Check death_130 ----
@@ -217,6 +274,21 @@ library(data.table)
                    c('Active', 'Calm', 'Moderate')) # ensure all strata are present
     })
 
+    test_that("death_130_count() zero-fills a `by` group with no deaths for a given infant cause", {
+      d <- data.table::copy(deathDT2)
+
+      codes <- unique(rads.data::icd_nchs130causes[cause.of.death == "Sudden infant death syndrome"]$icd10)
+      d[race == "AIAN" & underlying_cod_code %in% codes, underlying_cod_code := "I219"] # myocardial infarction
+
+      res <- suppressWarnings(death_130_count(ph.data = d,
+                                              cause = "Sudden infant death syndrome",
+                                              icdcol = "underlying_cod_code",
+                                              by = "race"))
+
+      expect_complete_table(res, c("race", "cause.of.death"), "deaths") # in helpers.R
+      expect_identical(res[race == "AIAN" & cause.of.death == "Sudden infant death syndrome"]$deaths, 0L)
+    })
+
 # Check death_multicause() ----
   # death_multicause() create data ----
   # not necessary
@@ -229,7 +301,7 @@ library(data.table)
     multiz <- death_multicause()
     expect_true(inherits(multiz, 'data.table'))
     expect_identical(c('cause_name', 'description'), names(multiz))
-    expect_true(grepl("opioid", multiz$cause_name, ignore.case = T))
+    expect_equal(sum(grepl("opioid", multiz$cause_name, ignore.case = T)), 1L)
   })
 
 # Check death_multicause_count ----
@@ -359,6 +431,24 @@ library(data.table)
       expect_identical(result.alt, result.og)
     })
 
+    test_that("death_multicause_count() zero-fills a `by` group with no deaths for the specified cause", {
+      d <- data.table::copy(deathDT2)
+
+      opioid_underlying <- unique(rads.data::icd10_multicause[underlying_contributing == "underlying"]$icd10)
+      d[race == "Multiple", underlying_cod_code := data.table::fifelse(underlying_cod_code %in% opioid_underlying,
+                                                                       "I219", underlying_cod_code)]
+
+      res <- death_multicause_count(ph.data = d,
+                                    cause_name = "Opioid",
+                                    icdcol = "underlying_cod_code",
+                                    contributing_cols = "record_axis_code",
+                                    by = "race")
+
+      expect_complete_table(res, c("race", "cause.of.death"), "deaths") # in helpers.R
+      expect_identical(res[race == "Multiple" & cause.of.death == "Opioid"]$deaths, 0L) # becuase I219 is myocardial infarction
+    })
+
+
 # Check death_other ----
   # death_other create data ----
   # not necessary
@@ -477,6 +567,21 @@ library(data.table)
         )
     })
 
+    test_that("death_other_count() zero-fills a `by` group with no deaths for the specified cause", {
+      d <- data.table::copy(deathDT2)
+
+      alc_codes <- unique(rads.data::icd_other_causes_of_death[cause.of.death == "Alcohol_Death"]$icd10)
+      d[race == "NHPI" & underlying_cod_code %in% alc_codes, underlying_cod_code := "I219"] # this is myocardial infarction
+
+      res <- death_other_count(ph.data = d,
+                               cause = "Alcohol_Death",
+                               icdcol = "underlying_cod_code",
+                               by = "race")
+
+      expect_complete_table(res, c("race", "cause.of.death"), "deaths") # in helpers.R
+      expect_identical(res[race == "NHPI" & cause.of.death == "Alcohol_Death"]$deaths, 0L)
+    })
+
 # Check death_injury_matrix_count ----
   # death_injury_matrix_count() create data ----
     deathDT <- rads.data::synthetic_death
@@ -558,6 +663,42 @@ library(data.table)
                  sort(c('mechanism', 'intent', 'deaths', 'temperament')))
     expect_equal(sort(unique(death_injury_matrix_count(ph.data = deathDT, icdcol = "underlying_cod_code", by = 'temperament')[]$temperament)),
                  sort(c('Active', 'Calm', 'Moderate')))
+  })
+
+  test_that("death_injury_matrix_count() zero-fills a `by` group with zero deaths for a mechanism x intent", {
+    d <- data.table::copy(deathDT2)
+
+    firearm_codes <- unique(rads.data::icd10_death_injury_matrix[mechanism == "Firearm" &
+                                                                   intent == "Unintentional"]$icd10)
+    d[race == "Hispanic" & underlying_cod_code %in% firearm_codes, underlying_cod_code := "I219"] # myocardial infarction
+
+    res <- death_injury_matrix_count(ph.data = d,
+                                     intent = "*",
+                                     mechanism = "*",
+                                     icdcol = "underlying_cod_code",
+                                     by = "race")
+
+    expect_complete_table(res, c("race", "mechanism", "intent"), "deaths") # in helpers.R
+    expect_identical(res[race == "Hispanic" & mechanism == "Firearm" & intent == "Unintentional"]$deaths, 0L)
+  })
+
+  test_that("death_injury_matrix_count() zero-fill still works with ypll_age specified", {
+    d <- data.table::copy(deathDT2)
+    firearm_codes <- unique(rads.data::icd10_death_injury_matrix[mechanism == "Firearm" &
+                                                                   intent == "Unintentional"]$icd10)
+    d[race == "Hispanic" & underlying_cod_code %in% firearm_codes, underlying_cod_code := "I219"] # myocardial infarction
+
+    res <- death_injury_matrix_count(ph.data = d,
+                                     intent = "*",
+                                     mechanism = "*",
+                                     icdcol = "underlying_cod_code",
+                                     by = "race",
+                                     ypll_age = 65,
+                                     death_age_col = "age")
+
+    expect_complete_table(res, c("race", "mechanism", "intent"), "deaths") # in helpers.R
+    expect_false(anyNA(res$ypll_65))
+    expect_identical(res[race == "Hispanic" & mechanism == "Firearm" & intent == "Unintentional"]$deaths, 0L)
   })
 
 # Check death_icd10_clean ----


### PR DESCRIPTION
- fixed generation of complete tables in chars_injury_matrix_count(), meaning tables with demographic combinations with zero counts are displayed as zero rather than missing rows for those demographic combos
- confirmed other chars and death counting functions return complete tables
- created many tests to check return of complete tables
- passes all tests 0 errors ✔ | 0 warnings ✔ | 1 note ✖